### PR TITLE
Version centralization, improve test coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2.2.1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python: [3.7, 3.8, 3.9]
+        python: [3.8, 3.9]
     steps:
       - name: Checking out code from GitHub
         uses: actions/checkout@v2.3.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
   "Framework :: AsyncIO",
   "Intended Audience :: Developers",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3",

--- a/src/elgato/__init__.py
+++ b/src/elgato/__init__.py
@@ -1,3 +1,5 @@
 """Asynchronous Python client for Elgato Key Lights."""
-from .elgato import Elgato, ElgatoConnectionError, ElgatoError  # noqa
-from .models import Info, State  # noqa
+from .elgato import Elgato, ElgatoConnectionError, ElgatoError
+from .models import Info, State
+
+__all__ = ["Elgato", "ElgatoConnectionError", "ElgatoError", "Info", "State"]

--- a/src/elgato/__version__.py
+++ b/src/elgato/__version__.py
@@ -1,3 +1,0 @@
-"""Asynchronous Python client for Elgato Key Lights."""
-
-__version__ = "1.0.0"

--- a/src/elgato/elgato.py
+++ b/src/elgato/elgato.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import asyncio
 import socket
+from importlib import metadata
 from typing import Any
 
 import aiohttp
 import async_timeout
 from yarl import URL
 
-from .__version__ import __version__
 from .exceptions import ElgatoConnectionError, ElgatoError
 from .models import Info, State
 
@@ -65,13 +65,14 @@ class Elgato:
             ElgatoError: Received an unexpected response from the Elgato Key
                 Light API.
         """
+        version = metadata.version(__package__)
         method = "GET" if data is None else "PUT"
         url = URL.build(
             scheme="http", host=self.host, port=self.port, path="/elgato/"
         ).join(URL(uri))
 
         headers = {
-            "User-Agent": f"PythonElgato/{__version__}",
+            "User-Agent": f"PythonElgato/{version}",
             "Accept": "application/json, text/plain, */*",
         }
 


### PR DESCRIPTION
- Improve test coverage
- Centralize versioning in pyproject.toml
- Drop Python 3.7 support
- Remove noqa's from package __init__