### PR TITLE
Use CI status for PR label checks

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,7 +3,7 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
 jobs:
@@ -18,4 +18,4 @@ jobs:
           valid-labels: >-
             breaking-change, bugfix, documentation, enhancement,
             refactor, performance, new-feature, maintenance, ci, dependencies
-          pull-request-number: "${{ github.event.pull_request.number }}"
+          disable-reviews: true


### PR DESCRIPTION
Let the PR label check use the CI build status (instead of PR reviews)