### PR TITLE
Fix missing display name handling

### DIFF
--- a/src/elgato/models.py
+++ b/src/elgato/models.py
@@ -20,7 +20,7 @@ class Info(BaseModel):
         serial_number: Serial number of the Elgato Light.
     """
 
-    display_name: str = Field(..., alias="displayName")
+    display_name: str = Field("Elgato Light", alias="displayName")
     firmware_build_number: int = Field(..., alias="firmwareBuildNumber")
     firmware_version: str = Field(..., alias="firmwareVersion")
     hardware_board_type: int = Field(..., alias="hardwareBoardType")

--- a/tests/fixtures/info-light-strip.json
+++ b/tests/fixtures/info-light-strip.json
@@ -4,6 +4,5 @@
   "firmwareBuildNumber": 211,
   "firmwareVersion": "1.0.4",
   "serialNumber": "EW52J1A00082",
-  "displayName": "New name",
   "features": ["lights"]
 }

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -54,3 +54,23 @@ async def test_change_display_name(aresponses):
     async with aiohttp.ClientSession() as session:
         elgato = Elgato("example.com", session=session)
         await elgato.display_name("OMG PUPPIES")
+
+
+@pytest.mark.asyncio
+async def test_missing_display_name(aresponses):
+    """Test ensure we can handle a missing display name."""
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/accessory-info",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("info-light-strip.json"),
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        info: Info = await elgato.info()
+        assert info
+        assert info.display_name == "Elgato Light"


### PR DESCRIPTION
# Proposed Changes

As shown by #394, some key lights are missing a display name?
This PR ensures we can handle that.

## Related Issues

fixes #394 
