### PR TITLE
Add support for fetching mac address & Wi-Fi information

### DIFF
--- a/src/elgato/models.py
+++ b/src/elgato/models.py
@@ -4,6 +4,23 @@ from enum import IntEnum
 from pydantic import BaseModel, Field
 
 
+class Wifi(BaseModel):
+    """Object holding the Elgato device Wi-Fi information.
+
+    This object holds wireles information about the Elgato device.
+
+    Attributes
+    ----------
+        frequency: The frequency in MHz of the Wi-Fi network connected.
+        rssi: The signal strength in dBm of the Wi-Fi network connected.
+        ssid: The SSID of the Wi-Fi network the device is connected to.
+    """
+
+    frequency: int = Field(..., alias="frequencyMHz")
+    rssi: int
+    ssid: str
+
+
 class Info(BaseModel):
     """Object holding the Elgato Light device information.
 
@@ -21,12 +38,14 @@ class Info(BaseModel):
     """
 
     display_name: str = Field("Elgato Light", alias="displayName")
+    features: list[str] = Field(...)
     firmware_build_number: int = Field(..., alias="firmwareBuildNumber")
     firmware_version: str = Field(..., alias="firmwareVersion")
     hardware_board_type: int = Field(..., alias="hardwareBoardType")
+    mac_address: str | None = Field(None, alias="macAddress")
     product_name: str = Field(..., alias="productName")
     serial_number: str = Field(..., alias="serialNumber")
-    features: list[str] = Field(...)
+    wifi: Wifi | None = Field(None, alias="wifi-info")
 
 
 class PowerOnBehavior(IntEnum):

--- a/tests/fixtures/info-key-light.json
+++ b/tests/fixtures/info-key-light.json
@@ -1,9 +1,16 @@
 {
   "productName": "Elgato Key Light",
   "hardwareBoardType": 53,
-  "firmwareBuildNumber": 192,
+  "hardwareRevision": 1,
+  "macAddress": "AA:BB:CC:DD:EE:FF",
+  "firmwareBuildNumber": 218,
   "firmwareVersion": "1.0.3",
   "serialNumber": "CN11A1A00001",
   "displayName": "Frenck",
-  "features": ["lights"]
+  "features": ["lights"],
+  "wifi-info": {
+    "ssid": "Frenck-IoT",
+    "frequencyMHz": 2400,
+    "rssi": -48
+  }
 }

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -8,8 +8,8 @@ from elgato import Elgato, Info
 from . import load_fixture
 
 
-async def test_info(aresponses: ResponsesMockServer) -> None:
-    """Test getting Elgato Light device information."""
+async def test_info_key_light(aresponses: ResponsesMockServer) -> None:
+    """Test getting Elgato Key Light device information."""
     aresponses.add(
         "example.com:9123",
         "/elgato/accessory-info",
@@ -26,11 +26,70 @@ async def test_info(aresponses: ResponsesMockServer) -> None:
         assert info
         assert info.display_name == "Frenck"
         assert info.features == ["lights"]
-        assert info.firmware_build_number == 192
+        assert info.firmware_build_number == 218
         assert info.firmware_version == "1.0.3"
         assert info.hardware_board_type == 53
+        assert info.mac_address == "AA:BB:CC:DD:EE:FF"
         assert info.product_name == "Elgato Key Light"
         assert info.serial_number == "CN11A1A00001"
+        assert info.wifi
+        assert info.wifi.frequency == 2400
+        assert info.wifi.rssi == -48
+        assert info.wifi.ssid == "Frenck-IoT"
+
+
+async def test_info_key_light_air(aresponses: ResponsesMockServer) -> None:
+    """Test getting Elgato Key Light Air device information."""
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/accessory-info",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("info-key-light-air.json"),
+        ),
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        info: Info = await elgato.info()
+        assert info
+        assert info.display_name == ""
+        assert info.features == ["lights"]
+        assert info.firmware_build_number == 195
+        assert info.firmware_version == "1.0.3"
+        assert info.hardware_board_type == 200
+        assert info.mac_address is None
+        assert info.product_name == "Elgato Key Light Air"
+        assert info.serial_number == "CW44J2A03032"
+        assert info.wifi is None
+
+
+async def test_info_light_strip(aresponses: ResponsesMockServer) -> None:
+    """Test getting Elgato Light Strip device information."""
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/accessory-info",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("info-light-strip.json"),
+        ),
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        info: Info = await elgato.info()
+        assert info
+        assert info.display_name == "Elgato Light"
+        assert info.features == ["lights"]
+        assert info.firmware_build_number == 211
+        assert info.firmware_version == "1.0.4"
+        assert info.hardware_board_type == 70
+        assert info.mac_address is None
+        assert info.product_name == "Elgato Light Strip"
+        assert info.serial_number == "EW52J1A00082"
+        assert info.wifi is None
 
 
 async def test_change_display_name(aresponses: ResponsesMockServer) -> None:


### PR DESCRIPTION
# Proposed Changes

Noticed newer firmware versions provide their mac address and Wi-Fi information in their device info. Extended the library to support that.

../Frenck