### PR TITLE
Test & linting environment tweaks

### DIFF
--- a/examples/ruff.toml
+++ b/examples/ruff.toml
@@ -1,0 +1,6 @@
+# This extend our general Ruff rules specifically for the examples
+extend = "../pyproject.toml"
+
+extend-ignore = [
+  "T201", # Allow the use of print() in examples
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -325,6 +325,21 @@ files = [
 ]
 
 [[package]]
+name = "covdefaults"
+version = "2.2.2"
+description = "A coverage plugin to provide sensible default settings"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "covdefaults-2.2.2-py2.py3-none-any.whl", hash = "sha256:10c193cbf290675961a09166d7cdea8a783655e04009f5493d50685fe6ec82f3"},
+    {file = "covdefaults-2.2.2.tar.gz", hash = "sha256:e543862ee0347769b47b27fa586d690e6b91587a3dcaaf8552fcfb1fac03d061"},
+]
+
+[package.dependencies]
+coverage = ">=6.0.2"
+
+[[package]]
 name = "coverage"
 version = "7.1.0"
 description = "Code coverage measurement for Python"
@@ -1553,4 +1568,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "dbf52bd669e7626633c3d51a1727b7e1dc849cef6637cf332ab0e08960237e29"
+content-hash = "5941f5771d286f118af3c2398750e6547c725e205f7ec7e8f825ddfad21497bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ pytest-cov = "^4.0.0"
 yamllint = "^1.29.0"
 safety = "^2.3.5"
 codespell = "^2.2.2"
+covdefaults = "^2.2.2"
 
 [tool.black]
 target-version = ['py39']
@@ -57,11 +58,8 @@ target-version = ['py39']
 [tool.coverage.paths]
 source = ["src"]
 
-[tool.coverage.report]
-show_missing = true
-
 [tool.coverage.run]
-branch = true
+plugins = ["covdefaults"]
 source = ["elgato"]
 
 [tool.mypy]


### PR DESCRIPTION
# Proposed Changes

- Set sane pytest coverage defaults using the `covdefaults` plugin.
- Allow the use of print statements in examples.




