### PR TITLE
Add support for controlling battery settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Known compatible and tested Elgato devices:
 
 - Elgato Key Light
 - Elgato Key Light Air
+- Elgato Key Light Mini
 - Elgato Light Strip
 
 ## Installation
@@ -56,8 +57,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())
 ```
 
 ## Changelog & Releases

--- a/examples/mini.py
+++ b/examples/mini.py
@@ -11,8 +11,8 @@ async def main() -> None:
     async with Elgato("10.10.11.172") as elgato:
         # General device information
         print(await elgato.info())
-        print(await elgato.settings())
-        print(state := await elgato.state())
+        print(settings := await elgato.settings())
+        print(await elgato.state())
 
         # General battery information
         battery = await elgato.battery()
@@ -21,8 +21,19 @@ async def main() -> None:
         print(f"Voltage: {battery.charge_voltage}V")
         print(f"Current: {battery.charge_current}A")
 
-        # Toggle the light
-        await elgato.light(on=(not state.on))
+        # Toggle the studio mode
+        if settings.battery is None:
+            raise RuntimeError
+        await elgato.battery_bypass(on=(not settings.battery.bypass))
+
+        # Adjust energy saving settings
+        await elgato.energy_saving(
+            on=True,
+            brightness=66,
+            disable_wifi=True,
+            minimum_battery_level=16,
+            adjust_brightness=True,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,9 +1,10 @@
 """Tests for retrieving information from the Elgato Light device."""
 
-from aiohttp import ClientSession
-from aresponses import ResponsesMockServer
+import pytest
+from aiohttp import ClientResponse, ClientSession
+from aresponses import Response, ResponsesMockServer
 
-from elgato import Elgato, Settings
+from elgato import Elgato, ElgatoNoBatteryError, Settings
 
 from . import load_fixture
 
@@ -96,3 +97,167 @@ async def test_settings_key_light_mini(aresponses: ResponsesMockServer) -> None:
         assert settings.power_on_temperature == 230
         assert settings.switch_off_duration == 300
         assert settings.switch_on_duration == 100
+
+
+async def test_battery_settings_keylight(aresponses: ResponsesMockServer) -> None:
+    """Test getting Elgato Light battery settings."""
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/lights/settings",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("settings-keylight.json"),
+        ),
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        with pytest.raises(ElgatoNoBatteryError):
+            await elgato.battery_settings()
+
+
+async def test_battery_settings_key_light_mini(aresponses: ResponsesMockServer) -> None:
+    """Test getting Elgato Light Mini device battery settings.
+
+    This device has a battery
+    """
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/lights/settings",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("settings-key-light-mini.json"),
+        ),
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        settings = await elgato.battery_settings()
+        assert settings
+        assert settings
+        assert settings.bypass is False
+        assert settings.energy_saving.disable_wifi is False
+        assert settings.energy_saving.enabled is False
+        assert settings.energy_saving.minimum_battery_level == 15
+        assert settings.energy_saving.adjust_brightness.brightness == 10
+        assert settings.energy_saving.adjust_brightness.enabled is False
+
+
+async def test_energy_savings_no_battery(aresponses: ResponsesMockServer) -> None:
+    """Test adjusting energy saving settings on a Elgato device without battery."""
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/lights/settings",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("settings-keylight.json"),
+        ),
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        assert await elgato.has_battery() is False
+        with pytest.raises(
+            ElgatoNoBatteryError,
+            match="The Elgato light does not have a battery.",
+        ):
+            await elgato.energy_saving(on=True)
+
+
+async def test_energy_savings_full(aresponses: ResponsesMockServer) -> None:
+    """Test changing energy saving settings."""
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/lights/settings",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("settings-key-light-mini.json"),
+        ),
+        repeat=2,
+    )
+
+    async def response_handler(request: ClientResponse) -> Response:
+        """Response handler for this test."""
+        data = await request.json()
+        assert data == {
+            "battery": {
+                "energySaving": {
+                    "adjustBrightness": {"brightness": 42, "enable": 1},
+                    "disableWifi": 1,
+                    "enable": 1,
+                    "minimumBatteryLevel": 21,
+                },
+            },
+        }
+        return aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text="{}",
+        )
+
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/lights/settings",
+        "PUT",
+        response_handler,
+    )
+
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        await elgato.energy_saving(
+            adjust_brightness=True,
+            brightness=42,
+            disable_wifi=True,
+            minimum_battery_level=21,
+            on=True,
+        )
+
+
+async def test_energy_savings_no_changes(aresponses: ResponsesMockServer) -> None:
+    """Test changing energy saving settings."""
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/lights/settings",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("settings-key-light-mini.json"),
+        ),
+        repeat=2,
+    )
+
+    async def response_handler(request: ClientResponse) -> Response:
+        """Response handler for this test."""
+        data = await request.json()
+        assert data == {
+            "battery": {
+                "energySaving": {
+                    "adjustBrightness": {"brightness": 10, "enable": False},
+                    "disableWifi": False,
+                    "enable": False,
+                    "minimumBatteryLevel": 15,
+                },
+            },
+        }
+        return aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text="{}",
+        )
+
+    aresponses.add(
+        "example.com:9123",
+        "/elgato/lights/settings",
+        "PUT",
+        response_handler,
+    )
+
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        await elgato.energy_saving()


### PR DESCRIPTION
# Proposed Changes

Adds/finishes adding full support for Elgato battery-powered devices, like the Elgato Key Light Mini.

Builds on top of #697 

Adds controls to:
- enable/disable studio mode
- control all aspects of energy saving.

closes #673 
