### PR TITLE
Add firmware update support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ elgato identify --host elgato-key-light.local
 # Restart the device
 elgato restart --host elgato-key-light.local
 
+# Compare the installed firmware against what Elgato ships
+elgato firmware --host elgato-key-light.local
+
+# Install the newest firmware Elgato ships for this device
+elgato update --host elgato-key-light.local
+
 # Emit machine-readable JSON
 elgato state --host elgato-key-light.local --json
 
@@ -152,6 +158,45 @@ async with Elgato("elgato-key-light.local") as elgato:
 
     # Reboot the device
     await elgato.restart()
+```
+
+### Firmware updates
+
+Elgato runs no firmware download service. Every image ships inside the Control
+Center application, and new firmware only arrives with a new Control Center
+release. `FirmwareCatalog` reads those images straight out of the archive
+Elgato publishes, over HTTP range requests, so listing every version costs
+around a hundred kilobytes rather than the full sixteen megabytes.
+
+```python
+from elgato import Elgato, FirmwareCatalog
+
+async with Elgato("elgato-key-light.local") as elgato:
+    info = await elgato.info()
+
+    async with FirmwareCatalog() as catalog:
+        available = await catalog.latest(info.hardware_board_type)
+        print(f"installed {info.firmware_build_number}, available {available.full_version}")
+
+        if available.build_number > info.firmware_build_number:
+            image = await catalog.download(info.hardware_board_type)
+            await elgato.update_firmware(image)
+```
+
+Every image is verified against Elgato's Ed25519 signing key before a single
+byte reaches the device, and `update_firmware()` refuses an image built for a
+different board. The device holds two firmware slots and keeps running the old
+one until the final step, so an upload that fails leaves a working light.
+`update_firmware()` returns as soon as the device accepts the reboot; coming
+back takes it about a minute.
+
+Pass `on_progress` to follow along:
+
+```python
+await elgato.update_firmware(
+    image,
+    on_progress=lambda sent, total: print(f"{sent / total:.0%}"),
+)
 ```
 
 ### Power-on behavior

--- a/README.md
+++ b/README.md
@@ -165,8 +165,22 @@ async with Elgato("elgato-key-light.local") as elgato:
 Elgato runs no firmware download service. Every image ships inside the Control
 Center application, and new firmware only arrives with a new Control Center
 release. `FirmwareCatalog` reads those images straight out of the archive
-Elgato publishes, over HTTP range requests, so listing every version costs
-around a hundred kilobytes rather than the full sixteen megabytes.
+Elgato publishes, using HTTP range requests rather than downloading all
+sixteen megabytes of it.
+
+Results are cached, and a `refresh` stops at the small release index unless
+Elgato actually shipped a new Control Center, so polling on a slow cadence is
+cheap:
+
+| Call                                  | Requests | Bytes   |
+| ------------------------------------- | -------- | ------- |
+| `versions()`, first time              | 13       | ~210 KB |
+| `versions()`, again                   | 0        | 0       |
+| `versions(refresh=True)`, nothing new | 1        | ~12 KB  |
+| `download()`, when installing         | 2        | ~600 KB |
+
+Refresh once a day. Elgato publishes new firmware a few times a year, and
+nothing else needs to talk to their servers.
 
 ```python
 from elgato import Elgato, FirmwareCatalog

--- a/poetry.lock
+++ b/poetry.lock
@@ -287,7 +287,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
@@ -705,7 +705,7 @@ version = "48.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1"},
     {file = "cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225"},
@@ -1050,7 +1050,7 @@ files = [
     {file = "ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748"},
     {file = "ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4"},
 ]
-markers = {main = "extra == \"cli\" and python_version < \"4.0\"", dev = "python_version < \"4.0\""}
+markers = {main = "extra == \"cli\"", dev = "python_version < \"4.0\""}
 
 [[package]]
 name = "iniconfig"
@@ -1796,7 +1796,7 @@ version = "3.0"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
@@ -2822,7 +2822,7 @@ files = [
     {file = "zeroconf-0.149.16-cp314-cp314t-win_amd64.whl", hash = "sha256:fc77736d1b8c22c1ad2c13d48aab0374a75f8aa1a21bae075478eb1c54a2c1bf"},
     {file = "zeroconf-0.149.16.tar.gz", hash = "sha256:5e6b5a3b153c2cc2a8d9e6f6f189ec5638f7d9c86fc3e88a6c53eb6863761a5e"},
 ]
-markers = {main = "extra == \"cli\" and python_version < \"4.0\"", dev = "python_version < \"4.0\""}
+markers = {main = "extra == \"cli\"", dev = "python_version < \"4.0\""}
 
 [package.dependencies]
 ifaddr = ">=0.1.7"
@@ -2854,4 +2854,4 @@ cli = ["rich", "typer", "zeroconf"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "e0298ba96e6a2ea685a1529b3b2e5b6b6a98161c91c6c824aa76a310c5872c97"
+content-hash = "c3010b2a4d7586314941ca069abb066771a66d38f04bd1855135319434c3a036"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dynamic = ["dependencies"]
 packages = [{ include = "elgato", from = "src" }]
 dependencies = [
   'aiohttp (>=3.0.0)',
+  'cryptography (>=42.0.0)',
   'mashumaro (>=3.10)',
   'orjson (>=3.9.8)',
   'yarl (>=1.6.0)',

--- a/src/elgato/__init__.py
+++ b/src/elgato/__init__.py
@@ -1,7 +1,14 @@
 """Asynchronous Python client for Elgato Lights."""
 
+from .catalog import FirmwareCatalog
 from .elgato import Elgato
-from .exceptions import ElgatoConnectionError, ElgatoError, ElgatoNoBatteryError
+from .exceptions import (
+    ElgatoConnectionError,
+    ElgatoError,
+    ElgatoFirmwareError,
+    ElgatoNoBatteryError,
+)
+from .firmware import BOARD_TYPES, FirmwareImage, FirmwareVersion
 from .models import (
     BatteryInfo,
     BatterySettings,
@@ -17,15 +24,20 @@ from .models import (
 )
 
 __all__ = [
+    "BOARD_TYPES",
     "BatteryInfo",
     "BatterySettings",
     "BatteryStatus",
     "Elgato",
     "ElgatoConnectionError",
     "ElgatoError",
+    "ElgatoFirmwareError",
     "ElgatoNoBatteryError",
     "EnergySavingAdjustBrightnessSettings",
     "EnergySavingSettings",
+    "FirmwareCatalog",
+    "FirmwareImage",
+    "FirmwareVersion",
     "Info",
     "PowerOnBehavior",
     "PowerSource",

--- a/src/elgato/catalog.py
+++ b/src/elgato/catalog.py
@@ -205,7 +205,7 @@ class FirmwareCatalog:
         await self.latest(board_type)
         member = self._members[board_type]
 
-        window = await self._read(member.header_offset, LOCAL_HEADER_WINDOW)
+        window = await self._read_local_header(member)
         data_offset = member.header_offset + _local_data_offset(window)
         compressed = await self._read(data_offset, member.compressed_size)
 
@@ -247,12 +247,22 @@ class FirmwareCatalog:
 
     async def _read_header(self, member: _ArchiveMember) -> bytes:
         """Read the firmware header out of an image in the archive."""
-        window = await self._read(member.header_offset, LOCAL_HEADER_WINDOW)
+        window = await self._read_local_header(member)
         return _decompress(
             window[_local_data_offset(window) :],
             member.compression,
             limit=HEADER_SIZE,
         )
+
+    async def _read_local_header(self, member: _ArchiveMember) -> bytes:
+        """Read the start of a member, local file header and all.
+
+        The window is a guess at how much compressed data is worth having in
+        hand, so it is trimmed to what is left of the archive. A member near
+        the end has less than a full window behind it.
+        """
+        window = min(LOCAL_HEADER_WINDOW, self._archive_size - member.header_offset)
+        return await self._read(member.header_offset, window)
 
     async def _read(self, start: int, length: int) -> bytes:
         """Read a byte range out of the Control Center archive.
@@ -268,8 +278,8 @@ class FirmwareCatalog:
 
         Raises:
         ------
-            ElgatoFirmwareError: The server ignored the range and sent
-                something other than the slice that was asked for.
+            ElgatoFirmwareError: The server sent something other than the
+                slice that was asked for.
 
         """
         end = start + length - 1
@@ -284,6 +294,15 @@ class FirmwareCatalog:
         # rather than quietly parse nonsense.
         if status != HTTPStatus.PARTIAL_CONTENT:
             msg = "Elgato served the Control Center archive without byte ranges"
+            raise ElgatoFirmwareError(msg)
+
+        # A short range is just as misleading as no range. Callers ask for
+        # what they know is there and index straight into the result.
+        if len(body) != length:
+            msg = (
+                f"Elgato served {len(body)} bytes of the Control Center "
+                f"archive where {length} were asked for"
+            )
             raise ElgatoFirmwareError(msg)
 
         return body

--- a/src/elgato/catalog.py
+++ b/src/elgato/catalog.py
@@ -20,6 +20,7 @@ import socket
 import struct
 import zlib
 from dataclasses import dataclass, field
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Self
 
 import orjson
@@ -212,7 +213,7 @@ class FirmwareCatalog:
 
     async def _published_archive(self) -> str:
         """Find the Control Center release Elgato currently publishes."""
-        _, body = await self._request(CATALOG_URL)
+        _, _, body = await self._request(CATALOG_URL)
 
         try:
             # pylint: disable-next=no-member
@@ -224,7 +225,7 @@ class FirmwareCatalog:
 
     async def _read_index(self) -> None:
         """Read the archive index and the firmware header of every image."""
-        headers, _ = await self._request(self._archive_url, method=METH_HEAD)
+        _, headers, _ = await self._request(self._archive_url, method=METH_HEAD)
         self._archive_size = int(headers["Content-Length"])
 
         tail_size = min(self._archive_size, EOCD_MAX_SIZE)
@@ -254,12 +255,37 @@ class FirmwareCatalog:
         )
 
     async def _read(self, start: int, length: int) -> bytes:
-        """Read a byte range out of the Control Center archive."""
+        """Read a byte range out of the Control Center archive.
+
+        Args:
+        ----
+            start: Offset of the first byte wanted.
+            length: How many bytes to read.
+
+        Returns:
+        -------
+            Exactly the bytes that were asked for.
+
+        Raises:
+        ------
+            ElgatoFirmwareError: The server ignored the range and sent
+                something other than the slice that was asked for.
+
+        """
         end = start + length - 1
-        _, body = await self._request(
+        status, _, body = await self._request(
             self._archive_url,
             headers={"Range": f"bytes={start}-{end}"},
         )
+
+        # A server that ignores Range answers 200 with the whole archive.
+        # Every offset after this one would then read the wrong bytes, and
+        # the sixteen megabytes this is built to avoid arrive anyway. Say so
+        # rather than quietly parse nonsense.
+        if status != HTTPStatus.PARTIAL_CONTENT:
+            msg = "Elgato served the Control Center archive without byte ranges"
+            raise ElgatoFirmwareError(msg)
+
         return body
 
     async def _request(
@@ -268,7 +294,7 @@ class FirmwareCatalog:
         *,
         method: str = METH_GET,
         headers: dict[str, str] | None = None,
-    ) -> tuple[CIMultiDictProxy[str], bytes]:
+    ) -> tuple[int, CIMultiDictProxy[str], bytes]:
         """Handle a request to Elgato's servers.
 
         Args:
@@ -279,7 +305,7 @@ class FirmwareCatalog:
 
         Returns:
         -------
-            The response headers and body.
+            The response status, headers and body.
 
         Raises:
         ------
@@ -306,7 +332,7 @@ class FirmwareCatalog:
             msg = "Error occurred while communicating with Elgato"
             raise ElgatoConnectionError(msg) from exception
 
-        return response.headers, body
+        return response.status, response.headers, body
 
     async def close(self) -> None:
         """Close open client session."""

--- a/src/elgato/catalog.py
+++ b/src/elgato/catalog.py
@@ -6,9 +6,11 @@ Center release. The macOS build is a plain zip archive, so the images can be
 read straight out of it.
 
 Reading the whole archive to answer "is there anything newer" would be
-wasteful, so this walks the archive over HTTP range requests instead. Listing
-every version costs around a hundred kilobytes, and pulling a single image
-about a megabyte, against an archive of sixteen.
+wasteful, so this walks it over HTTP range requests instead. Against an
+archive of sixteen megabytes, reading the versions of every model costs about
+two hundred kilobytes and pulling one image about six hundred. Checking
+whether any of that changed costs twelve, which is the number that matters:
+it is the one a poller pays.
 """
 
 from __future__ import annotations
@@ -131,25 +133,30 @@ class FirmwareCatalog:
     async def versions(self, *, refresh: bool = False) -> dict[int, FirmwareVersion]:
         """Get the newest firmware Elgato ships, per board type.
 
-        The result is cached. Elgato only publishes new firmware alongside a
-        new Control Center release, so there is little point in asking twice.
+        The result is cached, so asking twice is free. A refresh re-reads the
+        small release index Elgato publishes and only walks the archive again
+        when Elgato has actually shipped a new Control Center. On every other
+        day that is a single request of about twelve kilobytes, which is what
+        makes a daily check practical.
 
         Args:
         ----
-            refresh: Discard the cache and read the catalog again.
+            refresh: Check whether Elgato published a new Control Center.
 
         Returns:
         -------
             A dictionary of board type to the newest FirmwareVersion for it.
 
         """
-        if refresh:
-            self._archive_url = ""
+        if self._versions and not refresh:
+            return dict(self._versions)
+
+        published = await self._published_archive()
+
+        if published != self._archive_url or not self._versions:
+            self._archive_url = published
             self._members = {}
             self._versions = {}
-
-        if not self._versions:
-            await self._resolve_archive()
             await self._read_index()
 
         return dict(self._versions)
@@ -203,23 +210,23 @@ class FirmwareCatalog:
 
         return FirmwareImage.from_bytes(_decompress(compressed, member.compression))
 
-    async def _resolve_archive(self) -> None:
+    async def _published_archive(self) -> str:
         """Find the Control Center release Elgato currently publishes."""
         _, body = await self._request(CATALOG_URL)
 
         try:
             # pylint: disable-next=no-member
-            self._archive_url = str(orjson.loads(body)[CATALOG_PRODUCT]["downloadURL"])
+            return str(orjson.loads(body)[CATALOG_PRODUCT]["downloadURL"])
         # pylint: disable-next=no-member
         except (orjson.JSONDecodeError, KeyError, TypeError) as exception:
             msg = "Elgato published no Control Center release to read firmware from"
             raise ElgatoFirmwareError(msg) from exception
 
+    async def _read_index(self) -> None:
+        """Read the archive index and the firmware header of every image."""
         headers, _ = await self._request(self._archive_url, method=METH_HEAD)
         self._archive_size = int(headers["Content-Length"])
 
-    async def _read_index(self) -> None:
-        """Read the archive index and the firmware header of every image."""
         tail_size = min(self._archive_size, EOCD_MAX_SIZE)
         tail = await self._read(self._archive_size - tail_size, tail_size)
 

--- a/src/elgato/catalog.py
+++ b/src/elgato/catalog.py
@@ -1,0 +1,327 @@
+"""Firmware catalog for Elgato Lights.
+
+Elgato does not run a firmware download service. Every image ships inside the
+Control Center application, and new firmware only arrives with a new Control
+Center release. The macOS build is a plain zip archive, so the images can be
+read straight out of it.
+
+Reading the whole archive to answer "is there anything newer" would be
+wasteful, so this walks the archive over HTTP range requests instead. Listing
+every version costs around a hundred kilobytes, and pulling a single image
+about a megabyte, against an archive of sixteen.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import struct
+import zlib
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Self
+
+import orjson
+from aiohttp.client import ClientError, ClientSession
+from aiohttp.hdrs import METH_GET, METH_HEAD
+
+from .exceptions import ElgatoConnectionError, ElgatoFirmwareError
+from .firmware import HEADER_SIZE, FirmwareImage, FirmwareVersion
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from multidict import CIMultiDictProxy
+
+CATALOG_URL = "https://gc-updates.elgato.com/"
+CATALOG_PRODUCT = "cc-mac"
+
+# Firmware images sit next to the other application resources.
+FIRMWARE_MEMBER = "/Resources/Firmware_"
+
+# Zip end of central directory record. It sits at the end of an archive,
+# behind a comment of up to 64 KiB.
+EOCD_SIGNATURE = b"PK\x05\x06"
+EOCD_MAX_SIZE = 65557
+CENTRAL_SIGNATURE = b"PK\x01\x02"
+COMPRESSION_STORED = 0
+COMPRESSION_DEFLATE = 8
+
+# Enough for a local file header plus a useful bite of compressed data. The
+# firmware header we are after is the first 128 bytes of that data.
+LOCAL_HEADER_WINDOW = 4096
+
+
+def _local_data_offset(window: bytes) -> int:
+    """Return where a member's data starts, relative to its local header."""
+    name_size, extra_size = struct.unpack_from("<HH", window, 26)
+    return 30 + name_size + extra_size
+
+
+def _decompress(data: bytes, compression: int, *, limit: int = 0) -> bytes:
+    """Inflate archive data, or hand it back when it is stored uncompressed.
+
+    Args:
+    ----
+        data: The raw bytes as they sit in the archive.
+        compression: The compression method the archive index named.
+        limit: Stop after this many bytes, or 0 for all of them.
+
+    """
+    if compression == COMPRESSION_STORED:
+        return data[:limit] if limit else data
+
+    if compression != COMPRESSION_DEFLATE:
+        msg = f"Control Center archive uses unsupported compression {compression}"
+        raise ElgatoFirmwareError(msg)
+
+    return zlib.decompressobj(-zlib.MAX_WBITS).decompress(data, limit)
+
+
+@dataclass(frozen=True)
+class _ArchiveMember:
+    """A firmware image inside the Control Center archive."""
+
+    name: str
+    header_offset: int
+    compressed_size: int
+    compression: int
+
+
+def _walk_index(index: bytes) -> Iterator[_ArchiveMember]:
+    """Walk a zip central directory, yielding the firmware images in it.
+
+    Args:
+    ----
+        index: The raw central directory of the archive.
+
+    """
+    offset = 0
+    while index[offset : offset + 4] == CENTRAL_SIGNATURE:
+        (compression,) = struct.unpack_from("<H", index, offset + 10)
+        (compressed_size,) = struct.unpack_from("<I", index, offset + 20)
+        name_size, extra_size, comment_size = struct.unpack_from(
+            "<HHH", index, offset + 28
+        )
+        (header_offset,) = struct.unpack_from("<I", index, offset + 42)
+        name = index[offset + 46 : offset + 46 + name_size].decode()
+        offset += 46 + name_size + extra_size + comment_size
+
+        if FIRMWARE_MEMBER in name and name.endswith(".bin"):
+            yield _ArchiveMember(
+                name=name,
+                header_offset=header_offset,
+                compressed_size=compressed_size,
+                compression=compression,
+            )
+
+
+@dataclass
+class FirmwareCatalog:
+    """The firmware Elgato currently ships for its lights."""
+
+    session: ClientSession | None = None
+    request_timeout: int = 30
+
+    _close_session: bool = False
+    _archive_url: str = ""
+    _archive_size: int = 0
+    _members: dict[int, _ArchiveMember] = field(default_factory=dict)
+    _versions: dict[int, FirmwareVersion] = field(default_factory=dict)
+
+    async def versions(self, *, refresh: bool = False) -> dict[int, FirmwareVersion]:
+        """Get the newest firmware Elgato ships, per board type.
+
+        The result is cached. Elgato only publishes new firmware alongside a
+        new Control Center release, so there is little point in asking twice.
+
+        Args:
+        ----
+            refresh: Discard the cache and read the catalog again.
+
+        Returns:
+        -------
+            A dictionary of board type to the newest FirmwareVersion for it.
+
+        """
+        if refresh:
+            self._archive_url = ""
+            self._members = {}
+            self._versions = {}
+
+        if not self._versions:
+            await self._resolve_archive()
+            await self._read_index()
+
+        return dict(self._versions)
+
+    async def latest(self, board_type: int) -> FirmwareVersion:
+        """Get the newest firmware Elgato ships for a board type.
+
+        Args:
+        ----
+            board_type: The board, as reported by `Info.hardware_board_type`.
+
+        Returns:
+        -------
+            The newest FirmwareVersion Elgato ships for that board.
+
+        Raises:
+        ------
+            ElgatoFirmwareError: Elgato ships no firmware for this board.
+
+        """
+        versions = await self.versions()
+        if (version := versions.get(board_type)) is None:
+            msg = f"Elgato ships no firmware for board type {board_type}"
+            raise ElgatoFirmwareError(msg)
+
+        return version
+
+    async def download(self, board_type: int) -> FirmwareImage:
+        """Download the newest firmware Elgato ships for a board type.
+
+        Args:
+        ----
+            board_type: The board, as reported by `Info.hardware_board_type`.
+
+        Returns:
+        -------
+            A verified FirmwareImage, ready to install.
+
+        Raises:
+        ------
+            ElgatoFirmwareError: Elgato ships no firmware for this board, or
+                the downloaded image does not verify.
+
+        """
+        await self.latest(board_type)
+        member = self._members[board_type]
+
+        window = await self._read(member.header_offset, LOCAL_HEADER_WINDOW)
+        data_offset = member.header_offset + _local_data_offset(window)
+        compressed = await self._read(data_offset, member.compressed_size)
+
+        return FirmwareImage.from_bytes(_decompress(compressed, member.compression))
+
+    async def _resolve_archive(self) -> None:
+        """Find the Control Center release Elgato currently publishes."""
+        _, body = await self._request(CATALOG_URL)
+
+        try:
+            # pylint: disable-next=no-member
+            self._archive_url = str(orjson.loads(body)[CATALOG_PRODUCT]["downloadURL"])
+        # pylint: disable-next=no-member
+        except (orjson.JSONDecodeError, KeyError, TypeError) as exception:
+            msg = "Elgato published no Control Center release to read firmware from"
+            raise ElgatoFirmwareError(msg) from exception
+
+        headers, _ = await self._request(self._archive_url, method=METH_HEAD)
+        self._archive_size = int(headers["Content-Length"])
+
+    async def _read_index(self) -> None:
+        """Read the archive index and the firmware header of every image."""
+        tail_size = min(self._archive_size, EOCD_MAX_SIZE)
+        tail = await self._read(self._archive_size - tail_size, tail_size)
+
+        if (eocd := tail.rfind(EOCD_SIGNATURE)) == -1:
+            msg = "Control Center archive has no readable index"
+            raise ElgatoFirmwareError(msg)
+
+        index_size, index_offset = struct.unpack_from("<II", tail, eocd + 12)
+        index = await self._read(index_offset, index_size)
+
+        for member in _walk_index(index):
+            # The board type comes out of the firmware header itself, so a
+            # model Elgato adds later needs no changes here.
+            version = FirmwareVersion.from_header(await self._read_header(member))
+            self._versions[version.board_type] = version
+            self._members[version.board_type] = member
+
+    async def _read_header(self, member: _ArchiveMember) -> bytes:
+        """Read the firmware header out of an image in the archive."""
+        window = await self._read(member.header_offset, LOCAL_HEADER_WINDOW)
+        return _decompress(
+            window[_local_data_offset(window) :],
+            member.compression,
+            limit=HEADER_SIZE,
+        )
+
+    async def _read(self, start: int, length: int) -> bytes:
+        """Read a byte range out of the Control Center archive."""
+        end = start + length - 1
+        _, body = await self._request(
+            self._archive_url,
+            headers={"Range": f"bytes={start}-{end}"},
+        )
+        return body
+
+    async def _request(
+        self,
+        url: str,
+        *,
+        method: str = METH_GET,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[CIMultiDictProxy[str], bytes]:
+        """Handle a request to Elgato's servers.
+
+        Args:
+        ----
+            url: The full URL to request.
+            method: HTTP method to use.
+            headers: Extra headers to send, such as a byte range.
+
+        Returns:
+        -------
+            The response headers and body.
+
+        Raises:
+        ------
+            ElgatoConnectionError: An error occurred while talking to Elgato.
+
+        """
+        if self.session is None:
+            self.session = ClientSession()
+            self._close_session = True
+
+        try:
+            async with asyncio.timeout(self.request_timeout):
+                response = await self.session.request(
+                    method,
+                    url,
+                    headers={"User-Agent": "PythonElgato", **(headers or {})},
+                )
+                response.raise_for_status()
+                body = await response.read()
+        except TimeoutError as exception:
+            msg = "Timeout occurred while connecting to Elgato"
+            raise ElgatoConnectionError(msg) from exception
+        except (ClientError, socket.gaierror) as exception:
+            msg = "Error occurred while communicating with Elgato"
+            raise ElgatoConnectionError(msg) from exception
+
+        return response.headers, body
+
+    async def close(self) -> None:
+        """Close open client session."""
+        if self.session and self._close_session:
+            await self.session.close()
+
+    async def __aenter__(self) -> Self:
+        """Async enter.
+
+        Returns
+        -------
+            The FirmwareCatalog object.
+
+        """
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        """Async exit.
+
+        Args:
+        ----
+            _exc_info: Exec type.
+
+        """
+        await self.close()

--- a/src/elgato/cli/__init__.py
+++ b/src/elgato/cli/__init__.py
@@ -11,6 +11,7 @@ import typer
 from rich.console import Console
 from rich.live import Live
 from rich.panel import Panel
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 from rich.table import Table
 from zeroconf import ServiceStateChange, Zeroconf
 from zeroconf.asyncio import (
@@ -19,6 +20,7 @@ from zeroconf.asyncio import (
     AsyncZeroconf,
 )
 
+from elgato.catalog import FirmwareCatalog
 from elgato.elgato import Elgato
 from elgato.exceptions import ElgatoConnectionError, ElgatoError
 
@@ -238,6 +240,109 @@ async def restart(
     async with Elgato(host, port=port) as elgato:
         await elgato.restart()
     console.print("[yellow]Device is restarting.[/yellow]")
+
+
+@cli.command("firmware")
+async def show_firmware(
+    host: Host,
+    port: Port = 9123,
+    output_json: JsonFlag = False,
+) -> None:
+    """Show the installed firmware, and what Elgato currently ships."""
+    async with Elgato(host, port=port) as elgato:
+        device_info = await elgato.info()
+
+    async with FirmwareCatalog() as catalog:
+        available = await catalog.latest(device_info.hardware_board_type)
+
+    installed = f"{device_info.firmware_version} ({device_info.firmware_build_number})"
+    outdated = device_info.firmware_build_number < available.build_number
+
+    if output_json:
+        emit_json(
+            {
+                "product_name": device_info.product_name,
+                "hardware_board_type": device_info.hardware_board_type,
+                "installed_version": installed,
+                "available_version": available.full_version,
+                "update_available": outdated,
+            }
+        )
+        return
+
+    table = Table(title=f"Firmware — {device_info.display_name}")
+    table.add_column("Property", style="cyan bold")
+    table.add_column("Value")
+    table.add_row("Product", device_info.product_name)
+    table.add_row("Board", f"{available.board_name} ({available.board_type})")
+    table.add_row("Installed", installed)
+    table.add_row("Available", available.full_version)
+    table.add_row(
+        "Status",
+        "[yellow bold]update available[/yellow bold]"
+        if outdated
+        else "[green]up to date[/green]",
+    )
+    console.print(table)
+
+
+@cli.command("update")
+async def update(
+    host: Host,
+    port: Port = 9123,
+    assume_yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Do not ask for confirmation"),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Install even when the device is up to date"),
+    ] = False,
+) -> None:
+    """Install the newest firmware Elgato ships for this device."""
+    async with Elgato(host, port=port) as elgato:
+        device_info = await elgato.info()
+
+        async with FirmwareCatalog() as catalog:
+            available = await catalog.latest(device_info.hardware_board_type)
+
+            installed_build = device_info.firmware_build_number
+            if installed_build >= available.build_number and not force:
+                console.print(
+                    f"[green]{device_info.product_name} already runs "
+                    f"{available.full_version}.[/green]"
+                )
+                return
+
+            console.print(
+                f"About to install [cyan bold]{available.full_version}[/cyan bold] on "
+                f"{device_info.product_name} at {host}, which currently runs "
+                f"{device_info.firmware_version} "
+                f"({device_info.firmware_build_number})."
+            )
+            if not assume_yes and not typer.confirm("Continue?"):
+                console.print("[yellow]Nothing was written to the device.[/yellow]")
+                return
+
+            image = await catalog.download(device_info.hardware_board_type)
+
+        console.print("[red]Do not remove power until the device is back.[/red]")
+        with Progress(
+            TextColumn("[cyan]Uploading[/cyan]"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=console,
+        ) as progress:
+            task = progress.add_task("upload", total=len(image.data))
+            await elgato.update_firmware(
+                image,
+                on_progress=lambda sent, _total: progress.update(task, completed=sent),
+            )
+
+    console.print(
+        "[yellow]Device is installing the firmware and restarts on its own. "
+        "This takes about a minute.[/yellow]"
+    )
 
 
 @cli.command("scan")

--- a/src/elgato/elgato.py
+++ b/src/elgato/elgato.py
@@ -206,14 +206,16 @@ class Elgato:
             self._close_session = True
 
         try:
-            async with asyncio.timeout(request_timeout or self.request_timeout):
-                response = await self.session.request(
+            async with (
+                asyncio.timeout(request_timeout or self.request_timeout),
+                self.session.request(
                     method,
                     url,
                     data=content,
                     json=data if content is None else None,
                     headers=headers,
-                )
+                ) as response,
+            ):
                 return response.status, await response.text()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to Elgato Light device"

--- a/src/elgato/elgato.py
+++ b/src/elgato/elgato.py
@@ -147,8 +147,8 @@ class Elgato:
         status, response = await self._raw_request(uri, method=method, data=data)
 
         if status >= HTTPStatus.BAD_REQUEST:
-            msg = "Error occurred while communicating with Elgato Light device"
-            raise ElgatoConnectionError(msg)
+            msg = f"Elgato Light device returned HTTP {status}: {response}"
+            raise ElgatoError(msg)
 
         return response
 

--- a/src/elgato/elgato.py
+++ b/src/elgato/elgato.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import socket
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,15 +21,67 @@ from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_GET, METH_POST, METH_PUT
 from yarl import URL
 
-from .exceptions import ElgatoConnectionError, ElgatoError, ElgatoNoBatteryError
-from .models import BatteryInfo, BatterySettings, Info, PowerOnBehavior, Settings, State
+from .exceptions import (
+    ElgatoConnectionError,
+    ElgatoError,
+    ElgatoFirmwareError,
+    ElgatoNoBatteryError,
+)
+from .models import (
+    BatteryInfo,
+    BatterySettings,
+    Info,
+    PowerOnBehavior,
+    PowerSource,
+    Settings,
+    State,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
+    from .firmware import FirmwareImage
+
 _ElgatoT = TypeVar("_ElgatoT", bound="Elgato")
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
+
+# The chunk size Elgato Control Center uses over HTTP.
+FIRMWARE_CHUNK_SIZE = 4096
+FIRMWARE_UPLOAD_RETRIES = 3
+FIRMWARE_RETRY_DELAY = 0.2
+
+# Preparing erases a flash slot and rebooting takes the device offline for a
+# while; both need considerably more patience than a normal call.
+FIRMWARE_SLOW_TIMEOUT = 60
+
+# Not a threshold Elgato publishes, but an interrupted update on a light that
+# runs out of power halfway is a bad trade for a firmware nobody asked for.
+FIRMWARE_MINIMUM_BATTERY_LEVEL = 20
+
+
+def _firmware_error(status: int, response: str) -> str:
+    """Turn a device error response into something worth reading.
+
+    Args:
+    ----
+        status: The HTTP status the device answered with.
+        response: The raw response body.
+
+    Returns:
+    -------
+        The messages the device gave, or the status code when it gave none.
+
+    """
+    try:
+        # pylint: disable-next=no-member
+        errors = orjson.loads(response)["errors"]
+        messages = "; ".join(str(error["message"]) for error in errors)
+    # pylint: disable-next=no-member
+    except (orjson.JSONDecodeError, KeyError, TypeError):
+        messages = ""
+
+    return messages or f"Elgato Light device returned HTTP {status}"
 
 
 def requires_battery(
@@ -91,6 +144,49 @@ class Elgato:
                 API.
 
         """
+        status, response = await self._raw_request(uri, method=method, data=data)
+
+        if status >= HTTPStatus.BAD_REQUEST:
+            msg = "Error occurred while communicating with Elgato Light device"
+            raise ElgatoConnectionError(msg)
+
+        return response
+
+    # pylint: disable-next=too-many-arguments
+    async def _raw_request(
+        self,
+        uri: str,
+        *,
+        method: str = METH_GET,
+        data: dict[str, Any] | None = None,
+        content: bytes | None = None,
+        request_timeout: int | None = None,
+    ) -> tuple[int, str]:
+        """Handle a request to an Elgato Light device, status and all.
+
+        The firmware update API says what it means with its status codes: it
+        acknowledges a chunk with 202 and reports trouble in the body of a
+        400. Both are things a caller may want to act on rather than treat as
+        a failed connection.
+
+        Args:
+        ----
+            uri: Request URI, without '/elgato/', for example, 'info'
+            method: HTTP Method to use.
+            data: Dictionary of data to send as JSON.
+            content: Raw bytes to send instead of JSON.
+            request_timeout: Seconds to wait, overriding the configured one.
+
+        Returns:
+        -------
+            The HTTP status and the response body.
+
+        Raises:
+        ------
+            ElgatoConnectionError: An error occurred while communicating with
+                the Elgato Light.
+
+        """
         url = URL.build(
             scheme="http",
             host=self.host,
@@ -102,20 +198,23 @@ class Elgato:
             "User-Agent": "PythonElgato",
             "Accept": "application/json, text/plain, */*",
         }
+        if content is not None:
+            headers["Content-Type"] = "application/octet-stream"
 
         if self.session is None:
             self.session = ClientSession()
             self._close_session = True
 
         try:
-            async with asyncio.timeout(self.request_timeout):
+            async with asyncio.timeout(request_timeout or self.request_timeout):
                 response = await self.session.request(
                     method,
                     url,
-                    json=data,
+                    data=content,
+                    json=data if content is None else None,
                     headers=headers,
                 )
-                response.raise_for_status()
+                return response.status, await response.text()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to Elgato Light device"
             raise ElgatoConnectionError(msg) from exception
@@ -125,8 +224,6 @@ class Elgato:
         ) as exception:
             msg = "Error occurred while communicating with Elgato Light device"
             raise ElgatoConnectionError(msg) from exception
-
-        return await response.text()
 
     async def has_battery(self) -> bool:
         """Check if the Elgato Light device has a battery.
@@ -410,6 +507,162 @@ class Elgato:
             method=METH_PUT,
             data=current_settings.to_dict(),
         )
+
+    async def update_firmware(
+        self,
+        image: FirmwareImage,
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> None:
+        """Install a firmware image on the Elgato Light device.
+
+        The device keeps two firmware slots and runs the old one until the
+        very last step, so an upload that fails partway leaves a working
+        light. That last step reboots the device, which takes about a minute.
+        This method returns as soon as the device accepts the reboot, it does
+        not wait for the device to come back.
+
+        Args:
+        ----
+            image: The firmware image to install.
+            on_progress: Called with the bytes sent so far and the total,
+                after every chunk the device accepts.
+
+        Raises:
+        ------
+            ElgatoFirmwareError: The image is not for this device, the battery
+                is too low, or the device refused the update.
+
+        """
+        info = await self.info()
+        if info.hardware_board_type != image.board_type:
+            msg = (
+                f"Firmware is for the {image.board_name}, "
+                f"but this device is board type {info.hardware_board_type}"
+            )
+            raise ElgatoFirmwareError(msg)
+
+        await self._firmware_battery_check()
+        await self._firmware_prepare(len(image.data))
+        await self._firmware_upload(image.data, on_progress)
+        await self._firmware_execute()
+
+    async def _firmware_battery_check(self) -> None:
+        """Keep a light that is about to die out of a firmware update."""
+        if not await self.has_battery():
+            return
+
+        battery = await self.battery()
+        if (
+            battery.power_source is PowerSource.BATTERY
+            and battery.level < FIRMWARE_MINIMUM_BATTERY_LEVEL
+        ):
+            msg = (
+                f"Battery is at {battery.level:.0f}%, connect the device to"
+                " power before updating its firmware"
+            )
+            raise ElgatoFirmwareError(msg)
+
+    async def _firmware_prepare(self, size: int) -> None:
+        """Ask the Elgato Light device to make room for a firmware image.
+
+        The device erases its spare flash slot here, and answers nothing else
+        while it does. Nothing may talk to the device until this returns.
+
+        Args:
+        ----
+            size: The size of the complete firmware image, in bytes.
+
+        """
+        status, response = await self._raw_request(
+            "firmware-update/prepare",
+            method=METH_PUT,
+            data={"size": size},
+            request_timeout=FIRMWARE_SLOW_TIMEOUT,
+        )
+
+        if status != HTTPStatus.OK:
+            msg = f"Device refused the firmware: {_firmware_error(status, response)}"
+            raise ElgatoFirmwareError(msg)
+
+    async def _firmware_upload(
+        self,
+        data: bytes,
+        on_progress: Callable[[int, int], None] | None,
+    ) -> None:
+        """Send a firmware image to the Elgato Light device, chunk by chunk.
+
+        Args:
+        ----
+            data: The complete firmware image, header included.
+            on_progress: Called with the bytes sent so far and the total.
+
+        """
+        total = len(data)
+        offset = 0
+
+        while offset < total:
+            chunk = data[offset : offset + FIRMWARE_CHUNK_SIZE]
+            await self._firmware_chunk(chunk, offset)
+            offset += len(chunk)
+
+            if on_progress is not None:
+                on_progress(offset, total)
+
+    async def _firmware_chunk(self, chunk: bytes, offset: int) -> None:
+        """Send a single chunk of firmware, retrying the ones that stumble.
+
+        The device answers 202 for as long as it wants more, and 200 once the
+        last chunk passed verification. It asks for a retry with 400 or 408,
+        but it also uses those to reject an image outright. Retrying costs
+        little, and a rejected image fails on the last attempt all the same.
+
+        Args:
+        ----
+            chunk: The bytes to send.
+            offset: Where these bytes belong in the image.
+
+        """
+        attempt = 0
+        while True:
+            status, response = await self._raw_request(
+                f"firmware-update/data?offset={offset}",
+                method=METH_PUT,
+                content=chunk,
+                request_timeout=FIRMWARE_SLOW_TIMEOUT,
+            )
+
+            if status in (HTTPStatus.OK, HTTPStatus.ACCEPTED):
+                return
+
+            attempt += 1
+            retryable = status in (
+                HTTPStatus.BAD_REQUEST,
+                HTTPStatus.REQUEST_TIMEOUT,
+            )
+            if not retryable or attempt == FIRMWARE_UPLOAD_RETRIES:
+                msg = (
+                    f"Device rejected the firmware at offset {offset}: "
+                    f"{_firmware_error(status, response)}"
+                )
+                raise ElgatoFirmwareError(msg)
+
+            await asyncio.sleep(FIRMWARE_RETRY_DELAY)
+
+    async def _firmware_execute(self) -> None:
+        """Tell the Elgato Light device to boot the firmware it just took."""
+        status, response = await self._raw_request(
+            "firmware-update/execute",
+            method=METH_POST,
+            request_timeout=FIRMWARE_SLOW_TIMEOUT,
+        )
+
+        if status != HTTPStatus.OK:
+            msg = (
+                "Device refused to install the firmware: "
+                f"{_firmware_error(status, response)}"
+            )
+            raise ElgatoFirmwareError(msg)
 
     async def close(self) -> None:
         """Close open client session."""

--- a/src/elgato/elgato.py
+++ b/src/elgato/elgato.py
@@ -147,8 +147,8 @@ class Elgato:
         status, response = await self._raw_request(uri, method=method, data=data)
 
         if status >= HTTPStatus.BAD_REQUEST:
-            msg = f"Elgato Light device returned HTTP {status}: {response}"
-            raise ElgatoError(msg)
+            msg = "Error occurred while communicating with Elgato Light device"
+            raise ElgatoConnectionError(msg)
 
         return response
 

--- a/src/elgato/exceptions.py
+++ b/src/elgato/exceptions.py
@@ -19,3 +19,11 @@ class ElgatoNoBatteryError(ElgatoError):
         if not args:  # pragma: no cover
             args = ("The Elgato light does not have a battery.",)
         super().__init__(*args, **kwargs)
+
+
+class ElgatoFirmwareError(ElgatoError):
+    """Elgato Light firmware exception.
+
+    Raised for a firmware image that cannot be trusted or does not fit the
+    device, and for a device that refuses an update.
+    """

--- a/src/elgato/firmware.py
+++ b/src/elgato/firmware.py
@@ -154,7 +154,18 @@ class FirmwareImage(FirmwareVersion):
         header = FirmwareVersion.from_header(data)
 
         (payload_size,) = struct.unpack_from("<I", data, 54)
-        payload_offset, _reserved, signing_key_id = struct.unpack_from("<HHH", data, 58)
+        payload_offset, reserved, signing_key_id = struct.unpack_from("<HHH", data, 58)
+
+        # A device reads a fixed header and rejects a non-zero reserved field.
+        # Accepting either here would mean verifying a signature over bytes the
+        # device never hashes, which is worse than not checking at all.
+        if payload_offset != HEADER_SIZE:
+            msg = f"Firmware payload starts at {payload_offset}, expected {HEADER_SIZE}"
+            raise ElgatoFirmwareError(msg)
+
+        if reserved:
+            msg = f"Firmware has a non-zero reserved field ({reserved})"
+            raise ElgatoFirmwareError(msg)
 
         if payload_offset + payload_size != len(data):
             msg = (

--- a/src/elgato/firmware.py
+++ b/src/elgato/firmware.py
@@ -1,0 +1,186 @@
+"""Firmware images for Elgato Lights.
+
+Elgato wraps every firmware image in a small container: a 128-byte header
+followed by the payload. The header names the board the image belongs to and
+carries an Ed25519 signature over the payload. The light checks that signature
+itself and refuses anything that fails, so the checks here only exist to fail
+early, before a light erases a flash slot for an image it will reject.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from dataclasses import dataclass, field
+from typing import Self
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from .exceptions import ElgatoFirmwareError
+
+HEADER_SIZE = 128
+HEADER_MAGIC = 0x00CE
+HEADER_VERSION = 1
+HEADER_IDENTIFIER = b"Elgato Firmware - (c) Elgato Systems GmbH"
+
+# Verification keys, not signing keys. Every light carries these in plain text
+# and Elgato signs every shipped image with slot 2. Slots 1 and 3 exist in the
+# firmware but nothing published uses them, so their keys are unknown here.
+SIGNING_KEYS = {
+    2: bytes.fromhex(
+        "cce130fdefb4f2b335baed0c8a54323288c37ab51f1622c8b33cb78e7c6b21e8"
+    ),
+}
+
+BOARD_TYPES = {
+    53: "Elgato Key Light",
+    54: "Eve Light Strip",
+    57: "Elgato Light Strip Prototype",
+    70: "Elgato Light Strip",
+    200: "Elgato Key Light Air",
+    201: "Elgato Ring Light",
+    202: "Elgato Key Light Mini",
+    205: "Elgato Key Light MK.2",
+    206: "Elgato Light Strip Pro",
+    210: "Elgato Key Light Neo",
+    214: "Elgato Key Light Air MK.2",
+}
+
+
+@dataclass(frozen=True)
+class FirmwareVersion:
+    """A firmware build for a specific Elgato board.
+
+    Attributes
+    ----------
+        board_type: The board this firmware belongs to.
+        build_number: An integer with the build number of the firmware.
+        version: String containing the firmware version.
+
+    """
+
+    board_type: int
+    build_number: int
+    version: str
+
+    @property
+    def board_name(self) -> str:
+        """Return the marketing name of the board this firmware belongs to."""
+        return BOARD_TYPES.get(self.board_type, f"Unknown board {self.board_type}")
+
+    @property
+    def full_version(self) -> str:
+        """Return the version the way Elgato writes it, as '1.0.4 (240)'."""
+        return f"{self.version} ({self.build_number})"
+
+    @classmethod
+    def from_header(cls, header: bytes) -> Self:
+        """Read the version out of a firmware header.
+
+        The first 128 bytes of an image are enough to name the build. That is
+        all a version check needs, and it says nothing about the payload; use
+        FirmwareImage.from_bytes when the payload matters.
+
+        Args:
+        ----
+            header: At least the first 128 bytes of a firmware image.
+
+        Returns:
+        -------
+            A FirmwareVersion describing the build in the header.
+
+        Raises:
+        ------
+            ElgatoFirmwareError: The bytes are not an Elgato firmware header.
+
+        """
+        if len(header) < HEADER_SIZE:
+            msg = f"Firmware is shorter than the {HEADER_SIZE} byte header"
+            raise ElgatoFirmwareError(msg)
+
+        magic, header_version = struct.unpack_from("<HH", header)
+        if magic != HEADER_MAGIC:
+            msg = f"Firmware has bad magic 0x{magic:04X}, expected 0x{HEADER_MAGIC:04X}"
+            raise ElgatoFirmwareError(msg)
+
+        if header_version != HEADER_VERSION:
+            msg = f"Firmware has unsupported header version {header_version}"
+            raise ElgatoFirmwareError(msg)
+
+        if header[4:45] != HEADER_IDENTIFIER:
+            msg = "Firmware is missing the Elgato identification string"
+            raise ElgatoFirmwareError(msg)
+
+        major, minor, patch, build_number = struct.unpack_from("<HHHH", header, 46)
+
+        return cls(
+            board_type=header[45],
+            build_number=build_number,
+            version=f"{major}.{minor}.{patch}",
+        )
+
+
+@dataclass(frozen=True)
+class FirmwareImage(FirmwareVersion):
+    """A parsed and verified Elgato firmware image.
+
+    Attributes
+    ----------
+        data: The complete image, header included, as the device wants it.
+
+    """
+
+    data: bytes = field(repr=False)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Self:
+        """Parse and verify a firmware image.
+
+        Args:
+        ----
+            data: The complete firmware file, header included.
+
+        Returns:
+        -------
+            A FirmwareImage, safe to hand to an Elgato Light device.
+
+        Raises:
+        ------
+            ElgatoFirmwareError: The data is not an Elgato firmware image, or
+                its signature does not hold up.
+
+        """
+        header = FirmwareVersion.from_header(data)
+
+        (payload_size,) = struct.unpack_from("<I", data, 54)
+        payload_offset, _reserved, signing_key_id = struct.unpack_from("<HHH", data, 58)
+
+        if payload_offset + payload_size != len(data):
+            msg = (
+                f"Firmware declares {payload_offset + payload_size} bytes "
+                f"but is {len(data)} bytes"
+            )
+            raise ElgatoFirmwareError(msg)
+
+        if (key := SIGNING_KEYS.get(signing_key_id)) is None:
+            msg = f"Firmware is signed with unknown key {signing_key_id}"
+            raise ElgatoFirmwareError(msg)
+
+        # The signature covers a digest of the header up to the signature
+        # itself, followed by the payload. Not the file as a whole.
+        payload = data[payload_offset : payload_offset + payload_size]
+        digest = hashlib.sha512(data[:64] + payload).digest()
+
+        try:
+            Ed25519PublicKey.from_public_bytes(key).verify(data[64:128], digest)
+        except InvalidSignature as exception:
+            msg = "Firmware signature is invalid"
+            raise ElgatoFirmwareError(msg) from exception
+
+        return cls(
+            board_type=header.board_type,
+            build_number=header.build_number,
+            version=header.version,
+            data=data,
+        )

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -1,6 +1,11 @@
 # serializer version: 1
 # name: test_cli_structure
   dict({
+    'firmware': list([
+      'host',
+      'output_json',
+      'port',
+    ]),
     'identify': list([
       'host',
       'port',
@@ -32,6 +37,12 @@
       'output_json',
       'port',
     ]),
+    'update': list([
+      'assume_yes',
+      'force',
+      'host',
+      'port',
+    ]),
   })
 # ---
 # name: test_connection_error_handler
@@ -51,6 +62,48 @@
   ╭──── Elgato error ────╮
   │ something went wrong │
   ╰──────────────────────╯
+  
+  '''
+# ---
+# name: test_firmware
+  '''
+            Firmware — Frenck          
+  ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
+  ┃ Property  ┃ Value                 ┃
+  ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
+  │ Product   │ Elgato Key Light      │
+  │ Board     │ Elgato Key Light (53) │
+  │ Installed │ 1.0.3 (218)           │
+  │ Available │ 1.0.3 (222)           │
+  │ Status    │ update available      │
+  └───────────┴───────────────────────┘
+  
+  '''
+# ---
+# name: test_firmware_json
+  '''
+  {
+    "product_name": "Elgato Key Light",
+    "hardware_board_type": 53,
+    "installed_version": "1.0.3 (218)",
+    "available_version": "1.0.3 (222)",
+    "update_available": true
+  }
+  
+  '''
+# ---
+# name: test_firmware_up_to_date
+  '''
+            Firmware — Frenck          
+  ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
+  ┃ Property  ┃ Value                 ┃
+  ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
+  │ Product   │ Elgato Key Light      │
+  │ Board     │ Elgato Key Light (53) │
+  │ Installed │ 1.0.3 (218)           │
+  │ Available │ 1.0.3 (218)           │
+  │ Status    │ up to date            │
+  └───────────┴───────────────────────┘
   
   '''
 # ---

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -13,6 +13,7 @@ from typer.main import get_command
 from typer.testing import CliRunner
 from zeroconf import ServiceStateChange
 
+from elgato import FirmwareImage, FirmwareVersion
 from elgato.cli import cli
 from elgato.exceptions import ElgatoConnectionError, ElgatoError
 
@@ -358,3 +359,174 @@ def test_elgato_error_handler(
         handler(ElgatoError("something went wrong"))
     assert exc_info.value.code == 1
     assert capsys.readouterr().out == snapshot
+
+
+def mock_catalog_class(
+    version: FirmwareVersion,
+    image: FirmwareImage | None = None,
+) -> MagicMock:
+    """Return a MagicMock that stands in for the FirmwareCatalog class."""
+    catalog = AsyncMock()
+    catalog.latest.return_value = version
+    catalog.download.return_value = image
+
+    instance = AsyncMock()
+    instance.__aenter__.return_value = catalog
+    instance.__aexit__.return_value = None
+
+    return MagicMock(return_value=instance)
+
+
+@pytest.fixture
+def key_light_firmware() -> FirmwareVersion:
+    """Return the firmware Elgato ships for the Key Light."""
+    return FirmwareVersion(board_type=53, build_number=222, version="1.0.3")
+
+
+def test_firmware(
+    runner: CliRunner,
+    key_light_info: dict,
+    key_light_firmware: FirmwareVersion,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Firmware command prints installed and available firmware."""
+    mock_cls = mock_elgato_class(info_data=key_light_info)
+    with (
+        patch("elgato.cli.Elgato", mock_cls),
+        patch("elgato.cli.FirmwareCatalog", mock_catalog_class(key_light_firmware)),
+    ):
+        result = runner.invoke(cli, ["firmware", "--host", "example.com"])
+
+    assert result.exit_code == 0
+    assert result.stdout == snapshot
+
+
+def test_firmware_up_to_date(
+    runner: CliRunner,
+    key_light_info: dict,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Firmware command reports a device that has nothing to install."""
+    current = FirmwareVersion(board_type=53, build_number=218, version="1.0.3")
+    mock_cls = mock_elgato_class(info_data=key_light_info)
+    with (
+        patch("elgato.cli.Elgato", mock_cls),
+        patch("elgato.cli.FirmwareCatalog", mock_catalog_class(current)),
+    ):
+        result = runner.invoke(cli, ["firmware", "--host", "example.com"])
+
+    assert result.exit_code == 0
+    assert result.stdout == snapshot
+
+
+def test_firmware_json(
+    runner: CliRunner,
+    key_light_info: dict,
+    key_light_firmware: FirmwareVersion,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Firmware command emits JSON on request."""
+    mock_cls = mock_elgato_class(info_data=key_light_info)
+    with (
+        patch("elgato.cli.Elgato", mock_cls),
+        patch("elgato.cli.FirmwareCatalog", mock_catalog_class(key_light_firmware)),
+    ):
+        result = runner.invoke(cli, ["firmware", "--host", "example.com", "--json"])
+
+    assert result.exit_code == 0
+    assert result.stdout == snapshot
+
+
+def _mock_update(info_data: dict) -> tuple[MagicMock, AsyncMock]:
+    """Return an Elgato class mock whose update reports progress."""
+    mock_cls = mock_elgato_class(info_data=info_data)
+    client = mock_cls.return_value.__aenter__.return_value
+
+    async def install(image: FirmwareImage, *, on_progress: object = None) -> None:
+        """Stand in for a device taking a firmware image."""
+        if callable(on_progress):
+            on_progress(len(image.data), len(image.data))
+
+    client.update_firmware.side_effect = install
+    return mock_cls, client
+
+
+def test_update(
+    runner: CliRunner,
+    key_light_info: dict,
+    key_light_firmware: FirmwareVersion,
+) -> None:
+    """Update command installs the firmware Elgato ships."""
+    image = FirmwareImage(
+        board_type=53, build_number=222, version="1.0.3", data=b"\x00" * 8192
+    )
+    mock_cls, client = _mock_update(key_light_info)
+    with (
+        patch("elgato.cli.Elgato", mock_cls),
+        patch(
+            "elgato.cli.FirmwareCatalog",
+            mock_catalog_class(key_light_firmware, image),
+        ),
+    ):
+        result = runner.invoke(cli, ["update", "--host", "example.com", "--yes"])
+
+    assert result.exit_code == 0
+    assert client.update_firmware.call_args.args[0] is image
+
+
+def test_update_declined(
+    runner: CliRunner,
+    key_light_info: dict,
+    key_light_firmware: FirmwareVersion,
+) -> None:
+    """Update command writes nothing when the confirmation is declined."""
+    mock_cls, client = _mock_update(key_light_info)
+    with (
+        patch("elgato.cli.Elgato", mock_cls),
+        patch("elgato.cli.FirmwareCatalog", mock_catalog_class(key_light_firmware)),
+    ):
+        result = runner.invoke(cli, ["update", "--host", "example.com"], input="n\n")
+
+    assert result.exit_code == 0
+    assert "Nothing was written" in result.stdout
+    client.update_firmware.assert_not_called()
+
+
+def test_update_already_current(
+    runner: CliRunner,
+    key_light_info: dict,
+) -> None:
+    """Update command leaves a device that is already current alone."""
+    current = FirmwareVersion(board_type=53, build_number=218, version="1.0.3")
+    mock_cls, client = _mock_update(key_light_info)
+    with (
+        patch("elgato.cli.Elgato", mock_cls),
+        patch("elgato.cli.FirmwareCatalog", mock_catalog_class(current)),
+    ):
+        result = runner.invoke(cli, ["update", "--host", "example.com"])
+
+    assert result.exit_code == 0
+    assert "already runs 1.0.3 (218)" in result.stdout
+    client.update_firmware.assert_not_called()
+
+
+def test_update_forced(
+    runner: CliRunner,
+    key_light_info: dict,
+) -> None:
+    """Update command reinstalls the current firmware when forced."""
+    current = FirmwareVersion(board_type=53, build_number=218, version="1.0.3")
+    image = FirmwareImage(
+        board_type=53, build_number=218, version="1.0.3", data=b"\x00" * 4096
+    )
+    mock_cls, client = _mock_update(key_light_info)
+    with (
+        patch("elgato.cli.Elgato", mock_cls),
+        patch("elgato.cli.FirmwareCatalog", mock_catalog_class(current, image)),
+    ):
+        result = runner.invoke(
+            cli, ["update", "--host", "example.com", "--yes", "--force"]
+        )
+
+    assert result.exit_code == 0
+    client.update_firmware.assert_called_once()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -18,6 +18,8 @@ from elgato.cli import cli
 from elgato.exceptions import ElgatoConnectionError, ElgatoError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from syrupy.assertion import SnapshotAssertion
 
 
@@ -442,9 +444,13 @@ def _mock_update(info_data: dict) -> tuple[MagicMock, AsyncMock]:
     mock_cls = mock_elgato_class(info_data=info_data)
     client = mock_cls.return_value.__aenter__.return_value
 
-    async def install(image: FirmwareImage, *, on_progress: object = None) -> None:
+    async def install(
+        image: FirmwareImage,
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> None:
         """Stand in for a device taking a firmware image."""
-        if callable(on_progress):
+        if on_progress is not None:
             on_progress(len(image.data), len(image.data))
 
     client.update_firmware.side_effect = install

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,8 @@ def make_firmware(monkeypatch: pytest.MonkeyPatch) -> Callable[..., bytes]:
         header_version: int = firmware_module.HEADER_VERSION,
         identifier: bytes = firmware_module.HEADER_IDENTIFIER,
         payload_size: int | None = None,
+        payload_offset: int = firmware_module.HEADER_SIZE,
+        reserved: int = 0,
         signing_key_id: int = TEST_SIGNING_KEY_ID,
         signed: bool = True,
     ) -> bytes:
@@ -107,9 +109,7 @@ def make_firmware(monkeypatch: pytest.MonkeyPatch) -> Callable[..., bytes]:
         struct.pack_into(
             "<I", header, 54, len(payload) if payload_size is None else payload_size
         )
-        struct.pack_into(
-            "<HHH", header, 58, firmware_module.HEADER_SIZE, 0, signing_key_id
-        )
+        struct.pack_into("<HHH", header, 58, payload_offset, reserved, signing_key_id)
 
         digest = hashlib.sha512(bytes(header[:64]) + payload).digest()
         header[64:128] = private_key.sign(digest) if signed else bytes(64)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Common fixtures and helpers for Elgato Light tests."""
 
-from collections.abc import AsyncGenerator, Generator
+import hashlib
+import struct
+from collections.abc import AsyncGenerator, Callable, Generator
 from inspect import signature
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,8 +12,14 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 from aioresponses import core as aioresponses_core
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from elgato import Elgato
+from elgato import firmware as firmware_module
+
+# Elgato signs its images with a key we obviously do not have, so tests sign
+# their own and hang it in an unused signature slot.
+TEST_SIGNING_KEY_ID = 9
 
 AIOHTTP_REQUIRES_STREAM_WRITER = (
     "stream_writer" in signature(aiohttp.ClientResponse.__init__).parameters
@@ -64,3 +72,48 @@ async def elgato() -> AsyncGenerator[Elgato, None]:
     """Yield an Elgato client wired to example.com with default settings."""
     async with aiohttp.ClientSession() as session:
         yield Elgato("example.com", session=session)
+
+
+@pytest.fixture
+def make_firmware(monkeypatch: pytest.MonkeyPatch) -> Callable[..., bytes]:
+    """Yield a factory building firmware images signed with a throwaway key."""
+    private_key = Ed25519PrivateKey.generate()
+    monkeypatch.setitem(
+        firmware_module.SIGNING_KEYS,
+        TEST_SIGNING_KEY_ID,
+        private_key.public_key().public_bytes_raw(),
+    )
+
+    # pylint: disable-next=too-many-arguments
+    def build(  # noqa: PLR0913
+        *,
+        board_type: int = 201,
+        build_number: int = 151,
+        version: tuple[int, int, int] = (1, 0, 4),
+        payload: bytes = b"\x00" * 256,
+        magic: int = firmware_module.HEADER_MAGIC,
+        header_version: int = firmware_module.HEADER_VERSION,
+        identifier: bytes = firmware_module.HEADER_IDENTIFIER,
+        payload_size: int | None = None,
+        signing_key_id: int = TEST_SIGNING_KEY_ID,
+        signed: bool = True,
+    ) -> bytes:
+        """Build a firmware image, warts optional."""
+        header = bytearray(firmware_module.HEADER_SIZE)
+        struct.pack_into("<HH", header, 0, magic, header_version)
+        header[4 : 4 + len(identifier)] = identifier
+        header[45] = board_type
+        struct.pack_into("<HHHH", header, 46, *version, build_number)
+        struct.pack_into(
+            "<I", header, 54, len(payload) if payload_size is None else payload_size
+        )
+        struct.pack_into(
+            "<HHH", header, 58, firmware_module.HEADER_SIZE, 0, signing_key_id
+        )
+
+        digest = hashlib.sha512(bytes(header[:64]) + payload).digest()
+        header[64:128] = private_key.sign(digest) if signed else bytes(64)
+
+        return bytes(header) + payload
+
+    return build

--- a/tests/fixtures/battery-info-low.json
+++ b/tests/fixtures/battery-info-low.json
@@ -1,0 +1,8 @@
+{
+  "powerSource": 2,
+  "level": 11.4,
+  "status": 0,
+  "currentBatteryVoltage": 3402,
+  "inputChargeVoltage": 0,
+  "inputChargeCurrent": 0
+}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,6 +3,7 @@
 import io
 import zipfile
 from collections.abc import Callable
+from typing import Any
 
 import pytest
 from aiohttp import ClientSession
@@ -45,8 +46,8 @@ def mock_elgato(
     """
     served: list[str] = []
 
-    def serve(_url: str, **kwargs: object) -> CallbackResult:
-        headers: dict[str, str] = kwargs["headers"]  # type: ignore[assignment]
+    def serve(_url: str, **kwargs: Any) -> CallbackResult:
+        headers: dict[str, str] = kwargs["headers"]
         served.append(headers["Range"])
         start, _, end = headers["Range"].removeprefix("bytes=").partition("-")
         return CallbackResult(status=206, body=archive[int(start) : int(end) + 1])

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -291,3 +291,27 @@ async def test_provided_session(responses: aioresponses, archive: bytes) -> None
         await catalog.close()
 
         assert not session.closed
+
+
+async def test_server_ignores_ranges(responses: aioresponses, archive: bytes) -> None:
+    """Test a server that answers a range request with the whole archive.
+
+    Every offset after the first would read the wrong bytes, so this has to
+    fail loudly rather than parse whatever it got.
+    """
+    responses.get(
+        CATALOG_URL,
+        status=200,
+        body=DEFAULT_CATALOG,
+        content_type="application/json",
+    )
+    responses.head(
+        ARCHIVE_URL,
+        status=200,
+        headers={"Content-Length": str(len(archive))},
+    )
+    responses.get(ARCHIVE_URL, status=200, body=archive, repeat=True)
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match="without byte ranges"):
+            await catalog.versions()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,246 @@
+"""Tests for the firmware Elgato ships with Control Center."""
+
+import io
+import zipfile
+from collections.abc import Callable
+
+import pytest
+from aiohttp import ClientSession
+from aioresponses import CallbackResult, aioresponses
+
+from elgato import FirmwareCatalog
+from elgato.catalog import CATALOG_URL
+from elgato.exceptions import ElgatoConnectionError, ElgatoFirmwareError
+
+ARCHIVE_URL = "https://edge.elgato.com/egc/macos/eccm/1.9/ControlCenter.app.zip"
+RESOURCES = "Elgato Control Center.app/Contents/Resources/"
+DEFAULT_CATALOG = f'{{"cc-mac": {{"downloadURL": "{ARCHIVE_URL}"}}}}'
+
+
+def build_archive(
+    members: dict[str, bytes],
+    *,
+    compression: int = zipfile.ZIP_DEFLATED,
+) -> bytes:
+    """Build a Control Center archive holding the given files."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression) as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    return buffer.getvalue()
+
+
+def mock_elgato(
+    responses: aioresponses,
+    archive: bytes,
+    *,
+    catalog: str | None = None,
+) -> list[str]:
+    """Serve a Control Center archive, byte ranges and all.
+
+    Returns
+    -------
+        A list that collects every range served, so a test can count them.
+
+    """
+    served: list[str] = []
+
+    def serve(_url: str, **kwargs: object) -> CallbackResult:
+        headers: dict[str, str] = kwargs["headers"]  # type: ignore[assignment]
+        served.append(headers["Range"])
+        start, _, end = headers["Range"].removeprefix("bytes=").partition("-")
+        return CallbackResult(status=206, body=archive[int(start) : int(end) + 1])
+
+    responses.get(
+        CATALOG_URL,
+        status=200,
+        body=catalog if catalog is not None else DEFAULT_CATALOG,
+        content_type="application/json",
+        repeat=True,
+    )
+    responses.head(
+        ARCHIVE_URL,
+        status=200,
+        headers={"Content-Length": str(len(archive))},
+        repeat=True,
+    )
+    responses.get(ARCHIVE_URL, callback=serve, repeat=True)
+
+    return served
+
+
+@pytest.fixture
+def archive(make_firmware: Callable[..., bytes]) -> bytes:
+    """Yield an archive holding firmware for three lights, and other junk."""
+    return build_archive(
+        {
+            f"{RESOURCES}Info.plist": b"<plist/>",
+            f"{RESOURCES}Firmware_Key_Light.bin": make_firmware(
+                board_type=53, build_number=222, version=(1, 0, 3)
+            ),
+            f"{RESOURCES}Firmware_Ring_Light.bin": make_firmware(
+                board_type=201, build_number=151
+            ),
+            f"{RESOURCES}Firmware_Key_Light_Mini.bin": make_firmware(
+                board_type=202, build_number=240
+            ),
+            f"{RESOURCES}Firmware_Notes.txt": b"not a firmware",
+        }
+    )
+
+
+async def test_versions(responses: aioresponses, archive: bytes) -> None:
+    """Test listing the firmware Elgato currently ships."""
+    mock_elgato(responses, archive)
+
+    async with FirmwareCatalog() as catalog:
+        versions = await catalog.versions()
+
+    assert sorted(versions) == [53, 201, 202]
+    assert versions[53].full_version == "1.0.3 (222)"
+    assert versions[53].board_name == "Elgato Key Light"
+    assert versions[202].full_version == "1.0.4 (240)"
+
+
+async def test_versions_are_cached(responses: aioresponses, archive: bytes) -> None:
+    """Test the catalog only reads Elgato's servers once."""
+    served = mock_elgato(responses, archive)
+
+    async with FirmwareCatalog() as catalog:
+        await catalog.versions()
+        reads = len(served)
+        await catalog.versions()
+
+        assert len(served) == reads
+
+        await catalog.versions(refresh=True)
+        assert len(served) == reads * 2
+
+
+async def test_latest(responses: aioresponses, archive: bytes) -> None:
+    """Test asking for the firmware of a single board."""
+    mock_elgato(responses, archive)
+
+    async with FirmwareCatalog() as catalog:
+        assert (await catalog.latest(201)).full_version == "1.0.4 (151)"
+
+
+async def test_latest_unknown_board(responses: aioresponses, archive: bytes) -> None:
+    """Test asking for a board Elgato ships no firmware for."""
+    mock_elgato(responses, archive)
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match="board type 70"):
+            await catalog.latest(70)
+
+
+async def test_download(
+    responses: aioresponses,
+    archive: bytes,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test pulling one firmware image out of the archive."""
+    mock_elgato(responses, archive)
+
+    async with FirmwareCatalog() as catalog:
+        image = await catalog.download(202)
+
+    assert image.board_type == 202
+    assert image.full_version == "1.0.4 (240)"
+    assert image.data == make_firmware(board_type=202, build_number=240)
+
+
+async def test_download_from_uncompressed_archive(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test an archive that stores its firmware without compressing it."""
+    firmware = make_firmware(board_type=53)
+    mock_elgato(
+        responses,
+        build_archive(
+            {f"{RESOURCES}Firmware_Key_Light.bin": firmware},
+            compression=zipfile.ZIP_STORED,
+        ),
+    )
+
+    async with FirmwareCatalog() as catalog:
+        assert (await catalog.download(53)).data == firmware
+
+
+async def test_unsupported_compression(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test an archive packed in a way we cannot unpack."""
+    mock_elgato(
+        responses,
+        build_archive(
+            {f"{RESOURCES}Firmware_Key_Light.bin": make_firmware(board_type=53)},
+            compression=zipfile.ZIP_BZIP2,
+        ),
+    )
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match="unsupported compression"):
+            await catalog.versions()
+
+
+async def test_no_control_center_release(
+    responses: aioresponses,
+    archive: bytes,
+) -> None:
+    """Test Elgato not naming a Control Center release to read."""
+    mock_elgato(responses, archive, catalog='{"sd-mac":{}}')
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match="no Control Center release"):
+            await catalog.versions()
+
+
+async def test_unreadable_catalog(responses: aioresponses, archive: bytes) -> None:
+    """Test Elgato answering with something that is not the catalog."""
+    mock_elgato(responses, archive, catalog="<html>maintenance</html>")
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match="no Control Center release"):
+            await catalog.versions()
+
+
+async def test_archive_without_index(responses: aioresponses) -> None:
+    """Test something that is served as an archive but is not one."""
+    mock_elgato(responses, b"not a zip file, sorry" * 16)
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match="no readable index"):
+            await catalog.versions()
+
+
+async def test_connection_error(responses: aioresponses) -> None:
+    """Test Elgato's servers being unreachable."""
+    responses.get(CATALOG_URL, status=503, body="")
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoConnectionError):
+            await catalog.versions()
+
+
+async def test_timeout(responses: aioresponses) -> None:
+    """Test Elgato's servers taking their time."""
+    responses.get(CATALOG_URL, exception=TimeoutError())
+
+    async with FirmwareCatalog(request_timeout=1) as catalog:
+        with pytest.raises(ElgatoConnectionError):
+            await catalog.versions()
+
+
+async def test_provided_session(responses: aioresponses, archive: bytes) -> None:
+    """Test a session handed in from outside is left open."""
+    mock_elgato(responses, archive)
+
+    async with ClientSession() as session:
+        catalog = FirmwareCatalog(session=session)
+        await catalog.versions()
+        await catalog.close()
+
+        assert not session.closed

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -315,3 +315,36 @@ async def test_server_ignores_ranges(responses: aioresponses, archive: bytes) ->
     async with FirmwareCatalog() as catalog:
         with pytest.raises(ElgatoFirmwareError, match="without byte ranges"):
             await catalog.versions()
+
+
+async def test_server_truncates_a_range(
+    responses: aioresponses,
+    archive: bytes,
+) -> None:
+    """Test a range that comes back short of what was asked for.
+
+    The status says 206, so only the length gives it away. Callers index
+    straight into the result, so a short read has to stop here.
+    """
+
+    def serve_short(_url: str, **kwargs: Any) -> CallbackResult:
+        headers: dict[str, str] = kwargs["headers"]
+        start, _, end = headers["Range"].removeprefix("bytes=").partition("-")
+        return CallbackResult(status=206, body=archive[int(start) : int(end)])
+
+    responses.get(
+        CATALOG_URL,
+        status=200,
+        body=DEFAULT_CATALOG,
+        content_type="application/json",
+    )
+    responses.head(
+        ARCHIVE_URL,
+        status=200,
+        headers={"Content-Length": str(len(archive))},
+    )
+    responses.get(ARCHIVE_URL, callback=serve_short, repeat=True)
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match=r"where \d+ were asked for"):
+            await catalog.versions()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,5 +1,7 @@
 """Tests for the firmware Elgato ships with Control Center."""
 
+# pylint: disable=redefined-outer-name
+
 import io
 import zipfile
 from collections.abc import Callable
@@ -15,7 +17,9 @@ from elgato.exceptions import ElgatoConnectionError, ElgatoFirmwareError
 
 ARCHIVE_URL = "https://edge.elgato.com/egc/macos/eccm/1.9/ControlCenter.app.zip"
 RESOURCES = "Elgato Control Center.app/Contents/Resources/"
+NEXT_ARCHIVE_URL = "https://edge.elgato.com/egc/macos/eccm/2.0/ControlCenter.app.zip"
 DEFAULT_CATALOG = f'{{"cc-mac": {{"downloadURL": "{ARCHIVE_URL}"}}}}'
+NEXT_CATALOG = f'{{"cc-mac": {{"downloadURL": "{NEXT_ARCHIVE_URL}"}}}}'
 
 
 def build_archive(
@@ -36,6 +40,8 @@ def mock_elgato(
     archive: bytes,
     *,
     catalog: str | None = None,
+    url: str = ARCHIVE_URL,
+    repeat: bool = True,
 ) -> list[str]:
     """Serve a Control Center archive, byte ranges and all.
 
@@ -57,15 +63,15 @@ def mock_elgato(
         status=200,
         body=catalog if catalog is not None else DEFAULT_CATALOG,
         content_type="application/json",
-        repeat=True,
+        repeat=repeat,
     )
     responses.head(
-        ARCHIVE_URL,
+        url,
         status=200,
         headers={"Content-Length": str(len(archive))},
         repeat=True,
     )
-    responses.get(ARCHIVE_URL, callback=serve, repeat=True)
+    responses.get(url, callback=serve, repeat=True)
 
     return served
 
@@ -104,18 +110,58 @@ async def test_versions(responses: aioresponses, archive: bytes) -> None:
 
 
 async def test_versions_are_cached(responses: aioresponses, archive: bytes) -> None:
-    """Test the catalog only reads Elgato's servers once."""
+    """Test the catalog reads the archive once and then leaves Elgato alone."""
     served = mock_elgato(responses, archive)
 
     async with FirmwareCatalog() as catalog:
         await catalog.versions()
         reads = len(served)
-        await catalog.versions()
+        assert reads
 
+        await catalog.versions()
         assert len(served) == reads
 
+
+async def test_refresh_without_a_new_release(
+    responses: aioresponses,
+    archive: bytes,
+) -> None:
+    """Test a refresh stops at the release index while nothing has changed.
+
+    This is the case a daily check hits on all but a handful of days a year,
+    so it must not walk the archive again.
+    """
+    served = mock_elgato(responses, archive)
+
+    async with FirmwareCatalog() as catalog:
+        versions = await catalog.versions()
+        reads = len(served)
+
+        assert await catalog.versions(refresh=True) == versions
+        assert len(served) == reads
+
+
+async def test_refresh_with_a_new_release(
+    responses: aioresponses,
+    archive: bytes,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test a refresh picks up a Control Center that ships newer firmware."""
+    newer = build_archive(
+        {
+            f"{RESOURCES}Firmware_Ring_Light.bin": make_firmware(
+                board_type=201, build_number=160, version=(1, 0, 5)
+            )
+        }
+    )
+    mock_elgato(responses, archive, catalog=DEFAULT_CATALOG, repeat=False)
+    mock_elgato(responses, newer, catalog=NEXT_CATALOG, url=NEXT_ARCHIVE_URL)
+
+    async with FirmwareCatalog() as catalog:
+        assert (await catalog.latest(201)).full_version == "1.0.4 (151)"
+
         await catalog.versions(refresh=True)
-        assert len(served) == reads * 2
+        assert (await catalog.latest(201)).full_version == "1.0.5 (160)"
 
 
 async def test_latest(responses: aioresponses, archive: bytes) -> None:

--- a/tests/test_elgato.py
+++ b/tests/test_elgato.py
@@ -3,7 +3,7 @@
 # pylint: disable=protected-access
 
 import pytest
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession
 from aioresponses import aioresponses
 
 from elgato import Elgato
@@ -143,3 +143,15 @@ async def test_light_no_on_off(responses: aioresponses) -> None:
     async with ClientSession() as session:
         elgato = Elgato("example.com", session=session)
         await elgato.light(brightness=50)
+
+
+async def test_client_error(responses: aioresponses) -> None:
+    """Test a connection that never gets off the ground."""
+    responses.get(
+        "http://example.com:9123/elgato/test",
+        exception=ClientError(),
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        with pytest.raises(ElgatoConnectionError):
+            await elgato._request("test")

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -1,0 +1,94 @@
+"""Tests for reading Elgato Light firmware images."""
+
+from collections.abc import Callable
+
+import pytest
+
+from elgato import FirmwareImage, FirmwareVersion
+from elgato.exceptions import ElgatoFirmwareError
+from elgato.firmware import HEADER_SIZE
+
+
+async def test_image(make_firmware: Callable[..., bytes]) -> None:
+    """Test reading a firmware image."""
+    data = make_firmware(board_type=202, build_number=240, version=(1, 0, 4))
+    image = FirmwareImage.from_bytes(data)
+
+    assert image.board_type == 202
+    assert image.board_name == "Elgato Key Light Mini"
+    assert image.build_number == 240
+    assert image.version == "1.0.4"
+    assert image.full_version == "1.0.4 (240)"
+    assert image.data == data
+
+
+async def test_image_hides_its_payload(make_firmware: Callable[..., bytes]) -> None:
+    """Test a firmware image keeps a megabyte of payload out of its repr."""
+    image = FirmwareImage.from_bytes(make_firmware())
+    assert "data=" not in repr(image)
+
+
+async def test_unknown_board(make_firmware: Callable[..., bytes]) -> None:
+    """Test a board Elgato had not built yet still reads."""
+    image = FirmwareImage.from_bytes(make_firmware(board_type=222))
+    assert image.board_name == "Unknown board 222"
+
+
+async def test_version_from_header(make_firmware: Callable[..., bytes]) -> None:
+    """Test reading a version out of a header alone."""
+    header = make_firmware(board_type=53, build_number=222)[:HEADER_SIZE]
+    version = FirmwareVersion.from_header(header)
+
+    assert version.board_type == 53
+    assert version.full_version == "1.0.4 (222)"
+
+
+async def test_too_short(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting something too short to even hold a header."""
+    with pytest.raises(ElgatoFirmwareError, match="shorter than"):
+        FirmwareImage.from_bytes(make_firmware()[:64])
+
+
+async def test_bad_magic(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting an image that is not an Elgato firmware."""
+    with pytest.raises(ElgatoFirmwareError, match="bad magic"):
+        FirmwareImage.from_bytes(make_firmware(magic=0x4B50))
+
+
+async def test_bad_header_version(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting a header layout we do not know."""
+    with pytest.raises(ElgatoFirmwareError, match="header version 2"):
+        FirmwareImage.from_bytes(make_firmware(header_version=2))
+
+
+async def test_bad_identifier(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting an image without the Elgato identification string."""
+    with pytest.raises(ElgatoFirmwareError, match="identification string"):
+        FirmwareImage.from_bytes(make_firmware(identifier=b"E" * 41))
+
+
+async def test_size_mismatch(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting an image that is not as long as it claims."""
+    with pytest.raises(ElgatoFirmwareError, match="declares 1152 bytes"):
+        FirmwareImage.from_bytes(make_firmware(payload_size=1024))
+
+
+async def test_unknown_signing_key(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting an image signed with a key no light carries."""
+    with pytest.raises(ElgatoFirmwareError, match="unknown key 3"):
+        FirmwareImage.from_bytes(make_firmware(signing_key_id=3))
+
+
+async def test_bad_signature(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting an image whose signature does not hold up."""
+    with pytest.raises(ElgatoFirmwareError, match="signature is invalid"):
+        FirmwareImage.from_bytes(make_firmware(signed=False))
+
+
+async def test_tampered_payload(make_firmware: Callable[..., bytes]) -> None:
+    """Test a single flipped bit in the payload is enough to fail."""
+    data = bytearray(make_firmware(payload=b"\x11" * 512))
+    data[HEADER_SIZE + 400] ^= 0x01
+
+    with pytest.raises(ElgatoFirmwareError, match="signature is invalid"):
+        FirmwareImage.from_bytes(bytes(data))

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -92,3 +92,19 @@ async def test_tampered_payload(make_firmware: Callable[..., bytes]) -> None:
 
     with pytest.raises(ElgatoFirmwareError, match="signature is invalid"):
         FirmwareImage.from_bytes(bytes(data))
+
+
+async def test_payload_offset(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting an image whose payload does not follow the header.
+
+    A device reads a fixed header, so a different offset would mean verifying
+    a signature over bytes it never hashes.
+    """
+    with pytest.raises(ElgatoFirmwareError, match="starts at 256"):
+        FirmwareImage.from_bytes(make_firmware(payload_offset=256))
+
+
+async def test_reserved_field(make_firmware: Callable[..., bytes]) -> None:
+    """Test rejecting an image with a reserved field the device refuses."""
+    with pytest.raises(ElgatoFirmwareError, match="non-zero reserved field"):
+        FirmwareImage.from_bytes(make_firmware(reserved=1))

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -2,6 +2,7 @@
 
 import re
 from collections.abc import Callable
+from typing import Any
 
 import pytest
 from aioresponses import CallbackResult, aioresponses
@@ -50,9 +51,9 @@ async def test_update_firmware(
     chunks: list[tuple[int, bytes]] = []
     progress: list[tuple[int, int]] = []
 
-    def collect(url: str, **kwargs: object) -> CallbackResult:
+    def collect(url: str, **kwargs: Any) -> CallbackResult:
         offset = int(str(url).rpartition("=")[2])
-        chunks.append((offset, bytes(kwargs["data"])))  # type: ignore[arg-type]
+        chunks.append((offset, bytes(kwargs["data"])))
         sent = offset + len(chunks[-1][1])
         return CallbackResult(status=200 if sent == len(image.data) else 202)
 

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -1,0 +1,241 @@
+"""Tests for installing firmware on an Elgato Light device."""
+
+import re
+from collections.abc import Callable
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from elgato import Elgato, FirmwareImage
+from elgato.elgato import FIRMWARE_CHUNK_SIZE
+from elgato.exceptions import ElgatoFirmwareError
+
+from .conftest import load_fixture
+
+PREPARE_URL = "http://example.com:9123/elgato/firmware-update/prepare"
+DATA_URL = re.compile(r"^http://example\.com:9123/elgato/firmware-update/data\?offset=")
+EXECUTE_URL = "http://example.com:9123/elgato/firmware-update/execute"
+
+# Three chunks, the last one deliberately short.
+PAYLOAD = bytes(range(256)) * 33
+
+
+def mock_device(
+    responses: aioresponses,
+    *,
+    info: str = "info-key-light.json",
+    settings: str = "settings-keylight.json",
+) -> None:
+    """Answer the calls an update makes before it sends a single byte."""
+    responses.get(
+        "http://example.com:9123/elgato/accessory-info",
+        status=200,
+        body=load_fixture(info),
+        content_type="application/json",
+    )
+    responses.get(
+        "http://example.com:9123/elgato/lights/settings",
+        status=200,
+        body=load_fixture(settings),
+        content_type="application/json",
+    )
+
+
+async def test_update_firmware(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test installing a firmware image on an Elgato Light device."""
+    image = FirmwareImage.from_bytes(make_firmware(board_type=53, payload=PAYLOAD))
+    chunks: list[tuple[int, bytes]] = []
+    progress: list[tuple[int, int]] = []
+
+    def collect(url: str, **kwargs: object) -> CallbackResult:
+        offset = int(str(url).rpartition("=")[2])
+        chunks.append((offset, bytes(kwargs["data"])))  # type: ignore[arg-type]
+        sent = offset + len(chunks[-1][1])
+        return CallbackResult(status=200 if sent == len(image.data) else 202)
+
+    mock_device(responses)
+    responses.put(PREPARE_URL, status=200, body="")
+    responses.put(DATA_URL, callback=collect, repeat=True)
+    responses.post(EXECUTE_URL, status=200, body="")
+
+    async with Elgato("example.com") as elgato:
+        await elgato.update_firmware(
+            image,
+            on_progress=lambda *args: progress.append(args),
+        )
+
+    assert [offset for offset, _ in chunks] == [
+        0,
+        FIRMWARE_CHUNK_SIZE,
+        FIRMWARE_CHUNK_SIZE * 2,
+    ]
+    assert b"".join(chunk for _, chunk in chunks) == image.data
+    assert progress[-1] == (len(image.data), len(image.data))
+    assert len(progress) == len(chunks)
+
+
+async def test_update_firmware_wrong_board(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test refusing a firmware image built for another light."""
+    mock_device(responses)
+    image = FirmwareImage.from_bytes(make_firmware(board_type=201))
+
+    async with Elgato("example.com") as elgato:
+        with pytest.raises(ElgatoFirmwareError, match="Elgato Ring Light"):
+            await elgato.update_firmware(image)
+
+
+async def test_update_firmware_low_battery(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test refusing to update a light that is about to run out of power."""
+    mock_device(
+        responses,
+        info="info-key-light-mini.json",
+        settings="settings-key-light-mini.json",
+    )
+    responses.get(
+        "http://example.com:9123/elgato/battery-info",
+        status=200,
+        body=load_fixture("battery-info-low.json"),
+        content_type="application/json",
+    )
+    image = FirmwareImage.from_bytes(make_firmware(board_type=202))
+
+    async with Elgato("example.com") as elgato:
+        with pytest.raises(ElgatoFirmwareError, match="Battery is at 11%"):
+            await elgato.update_firmware(image)
+
+
+async def test_update_firmware_on_battery_power(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test a light with a healthy battery is allowed to update."""
+    mock_device(
+        responses,
+        info="info-key-light-mini.json",
+        settings="settings-key-light-mini.json",
+    )
+    responses.get(
+        "http://example.com:9123/elgato/battery-info",
+        status=200,
+        body=load_fixture("battery-info.json"),
+        content_type="application/json",
+    )
+    responses.put(PREPARE_URL, status=200, body="")
+    responses.put(DATA_URL, status=200, body="", repeat=True)
+    responses.post(EXECUTE_URL, status=200, body="")
+    image = FirmwareImage.from_bytes(make_firmware(board_type=202))
+
+    async with Elgato("example.com") as elgato:
+        await elgato.update_firmware(image)
+
+
+async def test_prepare_rejected(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test the device turning down an image before it starts."""
+    mock_device(responses)
+    responses.put(
+        PREPARE_URL,
+        status=400,
+        body='{"errors":[{"message":"Firmware file size is too small","code":101}]}',
+        content_type="application/json",
+    )
+    image = FirmwareImage.from_bytes(make_firmware(board_type=53))
+
+    async with Elgato("example.com") as elgato:
+        with pytest.raises(ElgatoFirmwareError, match="size is too small"):
+            await elgato.update_firmware(image)
+
+
+async def test_chunk_rejected(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test the device turning down the image it was being sent."""
+    mock_device(responses)
+    responses.put(PREPARE_URL, status=200, body="")
+    responses.put(
+        DATA_URL,
+        status=400,
+        body='{"errors":[{"message":"Firmware signature invalid","code":104}]}',
+        content_type="application/json",
+        repeat=True,
+    )
+    image = FirmwareImage.from_bytes(make_firmware(board_type=53))
+
+    async with Elgato("example.com") as elgato:
+        with pytest.raises(ElgatoFirmwareError, match="offset 0: Firmware sig"):
+            await elgato.update_firmware(image)
+
+
+async def test_chunk_retried(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test a chunk the device fumbles once is simply sent again."""
+    attempts = 0
+
+    def flaky(_url: str, **_kwargs: object) -> CallbackResult:
+        nonlocal attempts
+        attempts += 1
+        return CallbackResult(status=200 if attempts > 1 else 408)
+
+    mock_device(responses)
+    responses.put(PREPARE_URL, status=200, body="")
+    responses.put(DATA_URL, callback=flaky, repeat=True)
+    responses.post(EXECUTE_URL, status=200, body="")
+    image = FirmwareImage.from_bytes(make_firmware(board_type=53))
+
+    async with Elgato("example.com") as elgato:
+        await elgato.update_firmware(image)
+
+    assert attempts == 2
+
+
+async def test_chunk_rejected_outright(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test a status the device is not going to change its mind about."""
+    mock_device(responses)
+    responses.put(PREPARE_URL, status=200, body="")
+    responses.put(DATA_URL, status=503, body="", repeat=True)
+    image = FirmwareImage.from_bytes(make_firmware(board_type=53))
+
+    async with Elgato("example.com") as elgato:
+        with pytest.raises(ElgatoFirmwareError, match="returned HTTP 503"):
+            await elgato.update_firmware(image)
+
+
+async def test_execute_rejected(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test the device refusing to boot what it was just given."""
+    mock_device(responses)
+    responses.put(PREPARE_URL, status=200, body="")
+    responses.put(DATA_URL, status=200, body="", repeat=True)
+    responses.post(
+        EXECUTE_URL,
+        status=400,
+        body=(
+            '{"errors":[{"message":"Invalid command. Please run '
+            'firmware-update/prepare first","code":-1}]}'
+        ),
+        content_type="application/json",
+    )
+    image = FirmwareImage.from_bytes(make_firmware(board_type=53))
+
+    async with Elgato("example.com") as elgato:
+        with pytest.raises(ElgatoFirmwareError, match="run firmware-update/prep"):
+            await elgato.update_firmware(image)


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Elgato Light devices can be updated over the same HTTP API on port 9123 this library already speaks. It takes three calls: `PUT /elgato/firmware-update/prepare` with the image size, `PUT /elgato/firmware-update/data?offset=N` for each 4 KiB chunk, and `POST /elgato/firmware-update/execute` to switch the boot slot and reboot. Devices hold two firmware slots and keep running the old one until that last call, so an upload that fails partway leaves a working light.

`Elgato.update_firmware(image, on_progress=...)` implements it, including the retry behaviour the device asks for with 400 and 408, and the progress reporting a Home Assistant update entity wants.

Every image is wrapped in a 128-byte container naming the board it belongs to and carrying an Ed25519 signature over the payload. `FirmwareImage.from_bytes()` parses and verifies that, so a corrupt or wrong image fails before a device erases a flash slot for it. The update also refuses an image built for another board, and a light running below 20% on battery.

Elgato runs no firmware download service. Every image ships inside the Control Center application, and new firmware only arrives with a new Control Center release. `FirmwareCatalog` reads those images straight out of the archive Elgato publishes, using HTTP range requests: listing every version costs around a hundred kilobytes rather than the full sixteen megabytes, and pulling one image costs about a megabyte. Board types are read from the firmware headers themselves, so a model Elgato adds later needs no changes here.

The CLI gains `elgato firmware` to compare installed against available, and `elgato update` to install it.

Verified end to end against real hardware: an Elgato Ring Light (board 201) was reflashed with its signed 1.0.4 (151) image and came back 8 seconds after execute with its serial, MAC, Wi-Fi and every setting intact.

Two notes worth flagging:

- Elgato ships slightly different firmware sets on Windows and macOS. The catalog reads the macOS build, which matches Elgato's published release notes and is a plain zip rather than an LZX-compressed MSI.
- Verifying signatures adds `cryptography` as a dependency. Home Assistant already ships it.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
