### PR TITLE
Measure the library in the coverage gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,9 @@ zizmor = "1.24.1"
 
 [tool.coverage.run]
 plugins = ["covdefaults"]
-source = ["elgato"]
+# Not "source"; coverage cannot resolve a bare package name in a src layout,
+# so it measured nothing and covdefaults fell back to the working directory.
+source_pkgs = ["elgato"]
 
 [tool.coverage.report]
 show_missing = true
@@ -86,6 +88,7 @@ fail_under = 95
 omit = [
   "src/elgato/_cli.py",
   "src/elgato/cli/async_typer.py",
+  "tests/*",
 ]
 
 [tool.ty.environment]
@@ -110,7 +113,7 @@ ignore-imports = true
 max-line-length = 88
 
 [tool.pytest.ini_options]
-addopts = "--cov"
+addopts = "--cov=elgato"
 asyncio_mode = "auto"
 
 [tool.ruff.lint]


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The coverage gate has not been grading the library.

`[tool.coverage.run] source = ["elgato"]` cannot be resolved in a src layout. There is no `elgato` directory next to `pyproject.toml`, so coverage finds nothing, and `covdefaults` then fills in the working directory because the option reads as unset. Every run has been measuring the tests, and only the tests.

That is why the report has always looked like this, with 546 statements and not one of them from `src/`:

```
Name                    Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------
tests/cli/test_cli.py     175      2     12      2    98%   286, 318
tests/conftest.py          38      4      4      2    86%   27->29, 51-52, 65-66
-------------------------------------------------------------------
TOTAL                     546      6     16      4    98%
Required test coverage of 95.0% reached. Total coverage: 98.22%
```

Three changes:

- `source_pkgs` instead of `source`, which resolves a package by import rather than by path. That is what a src layout needs.
- `--cov=elgato` in the pytest options, so the measurement is stated outright rather than depending on which fallback happens to win. Fixing only the first one moved the problem instead of solving it: coverage then measured the working directory and pulled `examples/` into the gate, dropping it to 89%.
- `tests/*` omitted from the report, so the threshold sits on the code it was meant to protect rather than on a test suite that is trivially near 100% and pads the number.

After:

```
Name                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
src/elgato/cli/__init__.py     149     10     32     13    87%   131->133, 133->137, ...
------------------------------------------------------------------------
TOTAL                          406     10     84     13    95%
Required test coverage of 95.0% reached. Total coverage: 95.31%
```

Worth knowing: 95.31% clears the existing 95% bar, but only just, and it is thin because `src/elgato/cli/__init__.py` has been sitting at 87% with nothing to notice. I left the threshold and the CLI alone so this stays a diagnosis rather than a config change bundled with new tests. Covering those CLI gaps deserves its own pull request.

The margin is also transient. With #1903 on top, the same gate reports 97.32%.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Found while adding firmware update support in #1903.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
