### PR TITLE
Add transition durations, hardware revision, and ready for Python 3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,23 @@ async with Elgato("elgato-key-light.local") as elgato:
     )
 ```
 
+### Transition durations
+
+How long the light takes to fade when it is switched or changed, in
+milliseconds. Values left out keep whatever the device already had.
+
+```python
+async with Elgato("elgato-key-light.local") as elgato:
+    await elgato.transition_durations(
+        switch_on=100,
+        switch_off=300,
+        color_change=100,
+    )
+```
+
+The device does not check these. It answers `200` to a negative number and
+stores a `0`, so anything negative is refused here instead.
+
 ### Connection options
 
 All constructor arguments are keyword-only (except `host`):

--- a/src/elgato/cli/async_typer.py
+++ b/src/elgato/cli/async_typer.py
@@ -22,6 +22,7 @@ Adaptation of the snippet/code from:
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Callable  # pylint: disable=import-error
 from functools import wraps
 from typing import (
@@ -96,7 +97,7 @@ class AsyncTyper(SyncTyper):
         def decorator(
             func: Callable[_P, Coroutine[Any, Any, _R]],
         ) -> Callable[_P, Coroutine[Any, Any, _R]]:
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
 
                 @wraps(func)
                 def sync_func(*_args: _P.args, **_kwargs: _P.kwargs) -> _R:
@@ -151,7 +152,7 @@ class AsyncTyper(SyncTyper):
         def decorator(
             func: Callable[_P, Coroutine[Any, Any, _R]],
         ) -> Callable[_P, Coroutine[Any, Any, _R]]:
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
 
                 @wraps(func)
                 def sync_func(*_args: _P.args, **_kwargs: _P.kwargs) -> _R:

--- a/src/elgato/elgato.py
+++ b/src/elgato/elgato.py
@@ -490,24 +490,78 @@ class Elgato:
             temperature: The power on color temperature of the light, in mired.
 
         """
-        current_settings = await self.settings()
+        settings = await self.settings()
         if behavior is not None:
-            current_settings.power_on_behavior = behavior
+            settings.power_on_behavior = behavior
         if brightness is not None:
-            current_settings.power_on_brightness = brightness
+            settings.power_on_brightness = brightness
         if hue is not None:
-            current_settings.power_on_hue = hue
+            settings.power_on_hue = hue
         if temperature is not None:
-            current_settings.power_on_temperature = temperature
+            settings.power_on_temperature = temperature
 
-        # Unset battery if present, needs special handling
-        if current_settings.battery:
-            current_settings.battery = None
+        await self._write_settings(settings)
+
+    async def transition_durations(
+        self,
+        *,
+        color_change: int | None = None,
+        switch_off: int | None = None,
+        switch_on: int | None = None,
+    ) -> None:
+        """Change how long the Elgato Light device takes to change state.
+
+        The device does not check these values. It answers 200 to a negative
+        number and to a string alike, and quietly stores a 0, so anything
+        unreasonable is turned away here instead.
+
+        Args:
+        ----
+            color_change: Fade time of brightness and color changes, in ms.
+            switch_off: Fade out time when the light is turned off, in ms.
+            switch_on: Fade in time when the light is turned on, in ms.
+
+        Raises:
+        ------
+            ElgatoError: One of the provided durations is negative.
+
+        """
+        durations = {
+            "color_change": color_change,
+            "switch_off": switch_off,
+            "switch_on": switch_on,
+        }
+        for name, duration in durations.items():
+            if duration is not None and duration < 0:
+                msg = f"Transition duration {name} cannot be negative"
+                raise ElgatoError(msg)
+
+        settings = await self.settings()
+        if color_change is not None:
+            settings.color_change_duration = color_change
+        if switch_off is not None:
+            settings.switch_off_duration = switch_off
+        if switch_on is not None:
+            settings.switch_on_duration = switch_on
+
+        await self._write_settings(settings)
+
+    async def _write_settings(self, settings: Settings) -> None:
+        """Write settings back to the Elgato Light device.
+
+        Args:
+        ----
+            settings: The settings to store on the device.
+
+        """
+        # Battery settings have their own shape on the way in, and sending
+        # them back here makes the device refuse the lot.
+        settings.battery = None
 
         await self._request(
             "lights/settings",
             method=METH_PUT,
-            data=current_settings.to_dict(),
+            data=settings.to_dict(),
         )
 
     async def update_firmware(

--- a/src/elgato/elgato.py
+++ b/src/elgato/elgato.py
@@ -511,9 +511,9 @@ class Elgato:
     ) -> None:
         """Change how long the Elgato Light device takes to change state.
 
-        The device does not check these values. It answers 200 to a negative
-        number and to a string alike, and quietly stores a 0, so anything
-        unreasonable is turned away here instead.
+        A negative duration is refused here, because the device will not
+        refuse it: it answers 200 and quietly stores a zero, so nothing
+        downstream would ever report it.
 
         Args:
         ----

--- a/src/elgato/models.py
+++ b/src/elgato/models.py
@@ -213,6 +213,7 @@ class Info(BaseModel):
         firmware_build_number: An integer with the build number of the firmware.
         firmware_version: String containing the firmware version.
         hardware_board_type: An integer indicating the board revision.
+        hardware_revision: The revision of the board, if the device reports one.
         product_name: The product name.
         serial_number: Serial number of the Elgato Light.
 
@@ -228,6 +229,12 @@ class Info(BaseModel):
     serial_number: str = field(metadata=field_options(alias="serialNumber"))
     display_name: str = field(
         default="Elgato Light", metadata=field_options(alias="displayName")
+    )
+    # Devices are not consistent about this one. A Key Light sends the string
+    # "1", a Ring Light sends the number 0.2. It identifies a revision, it is
+    # not something to do arithmetic with, so it is kept as text.
+    hardware_revision: str | None = field(
+        default=None, metadata=field_options(alias="hardwareRevision")
     )
     mac_address: str | None = field(
         default=None, metadata=field_options(alias="macAddress")

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,5 +1,6 @@
 """Tests for retrieving information from the Elgato Key Light device."""
 
+import pytest
 from aiohttp import ClientSession
 from aioresponses import aioresponses
 
@@ -106,3 +107,34 @@ async def test_missing_display_name(responses: aioresponses) -> None:
         info: Info = await elgato.info()
         assert info
         assert info.display_name == "Elgato Light"
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expected"),
+    [
+        ("info-key-light.json", "1"),
+        ("info-key-light-mini.json", "0.1"),
+        ("info-light-strip.json", None),
+    ],
+)
+async def test_hardware_revision(
+    responses: aioresponses,
+    fixture: str,
+    expected: str | None,
+) -> None:
+    """Test the hardware revision, which devices report in varying shapes.
+
+    A Key Light sends the string "1", a Key Light Mini the number 0.1, and
+    an older Light Strip does not send it at all.
+    """
+    responses.get(
+        "http://example.com:9123/elgato/accessory-info",
+        status=200,
+        body=load_fixture(fixture),
+        content_type="application/json",
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        info = await elgato.info()
+
+    assert info.hardware_revision == expected

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,12 +1,35 @@
 """Tests for retrieving information from the Elgato Light device."""
 
+from typing import Any
+
 import pytest
 from aiohttp import ClientSession
-from aioresponses import aioresponses
+from aioresponses import CallbackResult, aioresponses
 
-from elgato import Elgato, ElgatoNoBatteryError, PowerOnBehavior, Settings
+from elgato import (
+    Elgato,
+    ElgatoError,
+    ElgatoNoBatteryError,
+    PowerOnBehavior,
+    Settings,
+)
 
 from .conftest import load_fixture
+
+
+def capture_settings(responses: aioresponses) -> list[dict[str, Any]]:
+    """Answer settings writes and collect what was sent to the device."""
+    payloads: list[dict[str, Any]] = []
+
+    def handler(_url: str, **kwargs: Any) -> CallbackResult:
+        payloads.append(kwargs["json"])
+        return CallbackResult(status=200, body="{}")
+
+    responses.put(
+        "http://example.com:9123/elgato/lights/settings",
+        callback=handler,
+    )
+    return payloads
 
 
 async def test_settings_keylight(responses: aioresponses) -> None:
@@ -231,3 +254,90 @@ async def test_power_on_behavior_no_changes(responses: aioresponses) -> None:
     async with ClientSession() as session:
         elgato = Elgato("example.com", session=session)
         await elgato.power_on_behavior()
+
+
+async def test_transition_durations(responses: aioresponses) -> None:
+    """Test changing the transition durations of an Elgato Light."""
+    responses.get(
+        "http://example.com:9123/elgato/lights/settings",
+        status=200,
+        body=load_fixture("settings-keylight.json"),
+        content_type="application/json",
+    )
+    payloads = capture_settings(responses)
+
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        await elgato.transition_durations(
+            color_change=250,
+            switch_off=500,
+            switch_on=750,
+        )
+
+    assert payloads[0] == {
+        "powerOnBehavior": 1,
+        "powerOnBrightness": 20,
+        "powerOnTemperature": 213,
+        "switchOnDurationMs": 750,
+        "switchOffDurationMs": 500,
+        "colorChangeDurationMs": 250,
+    }
+
+
+async def test_transition_durations_partial(responses: aioresponses) -> None:
+    """Test the durations left out keep the value the device already had."""
+    responses.get(
+        "http://example.com:9123/elgato/lights/settings",
+        status=200,
+        body=load_fixture("settings-keylight.json"),
+        content_type="application/json",
+    )
+    payloads = capture_settings(responses)
+
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        await elgato.transition_durations(color_change=0)
+
+    assert payloads[0]["colorChangeDurationMs"] == 0
+    assert payloads[0]["switchOnDurationMs"] == 100
+    assert payloads[0]["switchOffDurationMs"] == 300
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"color_change": -1}, "color_change"),
+        ({"switch_off": -1}, "switch_off"),
+        ({"switch_on": -250}, "switch_on"),
+    ],
+)
+async def test_transition_durations_negative(
+    kwargs: dict[str, int],
+    expected: str,
+) -> None:
+    """Test a negative duration is refused before the device sees it.
+
+    The device takes a negative number without complaint and stores a 0,
+    so nothing downstream would report this.
+    """
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        with pytest.raises(ElgatoError, match=f"{expected} cannot be negative"):
+            await elgato.transition_durations(**kwargs)
+
+
+async def test_transition_durations_drops_battery(responses: aioresponses) -> None:
+    """Test battery settings are not sent back with the other settings."""
+    responses.get(
+        "http://example.com:9123/elgato/lights/settings",
+        status=200,
+        body=load_fixture("settings-key-light-mini.json"),
+        content_type="application/json",
+    )
+    payloads = capture_settings(responses)
+
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        await elgato.transition_durations(switch_on=200)
+
+    assert "battery" not in payloads[0]


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Three small, unrelated things, batched because each is a handful of lines.

**Transition durations.** `switchOnDurationMs`, `switchOffDurationMs` and `colorChangeDurationMs` were already parsed into `Settings`, but nothing could write them. `transition_durations()` does, and leaves out what you leave out.

It refuses a negative value, because the device will not. Tested against a Ring Light: a `switchOnDurationMs` of `-5` gets a `200`, and so does the string `"traag"`, and in both cases the device quietly stores a `0`. Nothing downstream would ever report that, so it stops in the client. There is no upper bound, because I could not find one the device actually enforces and inventing one seemed worse than having none.

The read, modify, write dance this shares with `power_on_behavior()` moved into `_write_settings()`, including the bit where the battery object has to be dropped before writing.

**Hardware revision.** `Info` now carries `hardwareRevision`. Devices disagree about its type: a Key Light sends the string `"1"`, a Ring Light sends the number `0.2`, and older Light Strips do not send it at all. It is kept as `str | None`, because it names a revision rather than being a number you would do arithmetic on, and there are tests for all three shapes.

**Ready for Python 3.16.** The CLI called `asyncio.iscoroutinefunction`, which 3.14 deprecated and 3.16 removes:

```
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for
removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

`inspect.iscoroutinefunction` is what the warning itself points at. Silent on 3.13, so nothing flagged it until now.

While I was in there I ran the whole suite on 3.15.0b1: 118 passing, and after this change zero warnings from our own code. The dependency chain already has wheels for it. The remaining warnings are mashumaro reaching for `typing.ByteString`, which goes away in 3.17 and is not ours. I have not added 3.15 to the CI matrix; that seems worth doing once it is actually released rather than while it is a beta.

Verified against real hardware, a Key Light and a Ring Light: durations written and read back, settings restored byte for byte afterwards, hardware revision reading `'1'` and `'0.2'` respectively, negative values refused.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
