### PR TITLE
Add a Wi-Fi signal strength percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ async with Elgato("elgato-key-light-mini.local") as elgato:
     )
 ```
 
+### Wi-Fi signal
+
+Devices report their signal in dBm, which is awkward to put in front of a
+user. `signal_strength` maps it onto a percentage, from nothing at -100 dBm
+to as good as it gets at -50 dBm.
+
+```python
+async with Elgato("elgato-key-light.local") as elgato:
+    info = await elgato.info()
+    if info.wifi:
+        print(f"{info.wifi.rssi} dBm ({info.wifi.signal_strength}%)")
+```
+
 ### Device management
 
 ```python

--- a/src/elgato/cli/__init__.py
+++ b/src/elgato/cli/__init__.py
@@ -134,7 +134,10 @@ async def info(
         table.add_row("MAC address", device_info.mac_address)
     if device_info.wifi:
         table.add_row("Wi-Fi SSID", device_info.wifi.ssid)
-        table.add_row("Wi-Fi RSSI", f"{device_info.wifi.rssi} dBm")
+        table.add_row(
+            "Wi-Fi signal",
+            f"{device_info.wifi.rssi} dBm ({device_info.wifi.signal_strength}%)",
+        )
         table.add_row("Wi-Fi frequency", f"{device_info.wifi.frequency} MHz")
     console.print(table)
 

--- a/src/elgato/models.py
+++ b/src/elgato/models.py
@@ -117,6 +117,7 @@ class Wifi(BaseModel):
     ----------
         frequency: The frequency in MHz of the Wi-Fi network connected.
         rssi: The signal strength in dBm of the Wi-Fi network connected.
+        signal_strength: The signal strength as a percentage.
         ssid: The SSID of the Wi-Fi network the device is connected to.
 
     """
@@ -124,6 +125,15 @@ class Wifi(BaseModel):
     frequency: int = field(metadata=field_options(alias="frequencyMHz"))
     rssi: int
     ssid: str
+
+    @property
+    def signal_strength(self) -> int:
+        """Convert RSSI to signal strength percentage (0-100)."""
+        if self.rssi <= -100:
+            return 0
+        if self.rssi >= -50:
+            return 100
+        return 2 * (self.rssi + 100)
 
 
 class PowerSource(IntEnum):

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -120,7 +120,7 @@
   │ Hardware board  │ 53                │
   │ MAC address     │ AA:BB:CC:DD:EE:FF │
   │ Wi-Fi SSID      │ Frenck-IoT        │
-  │ Wi-Fi RSSI      │ -48 dBm           │
+  │ Wi-Fi signal    │ -48 dBm (100%)    │
   │ Wi-Fi frequency │ 2400 MHz          │
   └─────────────────┴───────────────────┘
   

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -13,7 +13,7 @@ from typer.main import get_command
 from typer.testing import CliRunner
 from zeroconf import ServiceStateChange
 
-from elgato import FirmwareImage, FirmwareVersion
+from elgato import FirmwareImage, FirmwareVersion, Wifi
 from elgato.cli import cli
 from elgato.exceptions import ElgatoConnectionError, ElgatoError
 
@@ -67,10 +67,8 @@ def mock_elgato_class(
 @pytest.fixture
 def key_light_info() -> dict:
     """Return sample Key Light device info."""
-    wifi = MagicMock()
-    wifi.ssid = "Frenck-IoT"
-    wifi.rssi = -48
-    wifi.frequency = 2400
+    # The real model, so the signal strength percentage is actually computed.
+    wifi = Wifi(frequency=2400, rssi=-48, ssid="Frenck-IoT")
     return {
         "product_name": "Elgato Key Light",
         "serial_number": "CN11A1A00001",

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,5 +1,7 @@
 """Tests for retrieving information from the Elgato Key Light device."""
 
+import json
+
 import pytest
 from aiohttp import ClientSession
 from aioresponses import aioresponses
@@ -138,3 +140,42 @@ async def test_hardware_revision(
         info = await elgato.info()
 
     assert info.hardware_revision == expected
+
+
+@pytest.mark.parametrize(
+    ("rssi", "expected"),
+    [
+        (-100, 0),
+        (-90, 20),
+        (-60, 80),
+        (-50, 100),
+        (-120, 0),
+        (-10, 100),
+    ],
+)
+async def test_wifi_signal_strength(
+    responses: aioresponses,
+    rssi: int,
+    expected: int,
+) -> None:
+    """Test the Wi-Fi signal strength as a percentage.
+
+    A device reports dBm, which nothing outside a spectrum analyzer reads
+    comfortably. The scale runs from -100 dBm, which is nothing, to -50 dBm,
+    which is as good as it gets.
+    """
+    info = json.loads(load_fixture("info-key-light.json"))
+    info["wifi-info"]["rssi"] = rssi
+    responses.get(
+        "http://example.com:9123/elgato/accessory-info",
+        status=200,
+        body=json.dumps(info),
+        content_type="application/json",
+    )
+    async with ClientSession() as session:
+        elgato = Elgato("example.com", session=session)
+        device_info = await elgato.info()
+
+    assert device_info.wifi
+    assert device_info.wifi.rssi == rssi
+    assert device_info.wifi.signal_strength == expected


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds `Wifi.signal_strength`, the RSSI as a percentage.

Devices report dBm. That is the honest unit, but it is not a number to put in front of someone, and Home Assistant does not allow an integration to do the conversion on its side, so the library has to. This uses the same mapping as python-fumis: nothing at -100 dBm, as good as it gets at -50, linear in between.

```python
@property
def signal_strength(self) -> int:
    """Convert RSSI to signal strength percentage (0-100)."""
    if self.rssi <= -100:
        return 0
    if self.rssi >= -50:
        return 100
    return 2 * (self.rssi + 100)
```

The CLI now prints both, the way Fumis does:

```
│ Wi-Fi signal    │ -49 dBm (100%)    │
```

Checked against real hardware. A Key Light at -58 dBm reads 84%, a Ring Light at -49 dBm reads 100%.

This unblocks a Wi-Fi signal sensor in the Home Assistant integration, which was left out of home-assistant/core#180717 for exactly this reason.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
