### PR TITLE
Do not let a refresh move the archive under a download

### DIFF
--- a/src/elgato/catalog.py
+++ b/src/elgato/catalog.py
@@ -126,6 +126,10 @@ class FirmwareCatalog:
     request_timeout: int = 30
 
     _close_session: bool = False
+    # Reading the archive takes several requests against offsets that only
+    # hold for the archive they came from. A refresh that lands halfway
+    # through would leave the rest of them pointing into a different file.
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _archive_url: str = ""
     _archive_size: int = 0
     _members: dict[int, _ArchiveMember] = field(default_factory=dict)
@@ -149,8 +153,22 @@ class FirmwareCatalog:
             A dictionary of board type to the newest FirmwareVersion for it.
 
         """
-        if self._versions and not refresh:
+        async with self._lock:
+            await self._load(refresh=refresh)
             return dict(self._versions)
+
+    async def _load(self, *, refresh: bool = False) -> None:
+        """Read the archive index, once, or again when asked.
+
+        Callers hold the lock; everything this touches is shared.
+
+        Args:
+        ----
+            refresh: Check whether Elgato published a new Control Center.
+
+        """
+        if self._versions and not refresh:
+            return
 
         published = await self._published_archive()
 
@@ -159,8 +177,6 @@ class FirmwareCatalog:
             self._members = {}
             self._versions = {}
             await self._read_index()
-
-        return dict(self._versions)
 
     async def latest(self, board_type: int) -> FirmwareVersion:
         """Get the newest firmware Elgato ships for a board type.
@@ -202,12 +218,16 @@ class FirmwareCatalog:
                 the downloaded image does not verify.
 
         """
-        await self.latest(board_type)
-        member = self._members[board_type]
+        async with self._lock:
+            await self._load()
 
-        window = await self._read_local_header(member)
-        data_offset = member.header_offset + _local_data_offset(window)
-        compressed = await self._read(data_offset, member.compressed_size)
+            if (member := self._members.get(board_type)) is None:
+                msg = f"Elgato ships no firmware for board type {board_type}"
+                raise ElgatoFirmwareError(msg)
+
+            window = await self._read_local_header(member)
+            data_offset = member.header_offset + _local_data_offset(window)
+            compressed = await self._read(data_offset, member.compressed_size)
 
         return FirmwareImage.from_bytes(_decompress(compressed, member.compression))
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,11 +1,13 @@
 """Tests for the firmware Elgato ships with Control Center."""
 
-# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access,redefined-outer-name
 
+import asyncio
 import io
 import zipfile
 from collections.abc import Callable
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from aiohttp import ClientSession
@@ -348,3 +350,62 @@ async def test_server_truncates_a_range(
     async with FirmwareCatalog() as catalog:
         with pytest.raises(ElgatoFirmwareError, match=r"where \d+ were asked for"):
             await catalog.versions()
+
+
+async def test_refresh_during_a_download(
+    responses: aioresponses,
+    make_firmware: Callable[..., bytes],
+) -> None:
+    """Test Elgato publishing a new release while an image is downloading.
+
+    A download reads the archive in pieces. If a refresh swaps the archive
+    out between two of them, the later pieces come from a different file at
+    offsets that belong to the old one.
+    """
+    firmware = make_firmware(board_type=53, build_number=222, version=(1, 0, 3))
+    first = build_archive({f"{RESOURCES}Firmware_Key_Light.bin": firmware})
+    # Padding ahead of it, so the same member sits somewhere else entirely.
+    second = build_archive(
+        {
+            f"{RESOURCES}Notes.txt": b"n" * 40_000,
+            f"{RESOURCES}Firmware_Key_Light.bin": firmware,
+        }
+    )
+
+    async with FirmwareCatalog() as catalog:
+        served = mock_elgato(responses, first, catalog=DEFAULT_CATALOG, repeat=False)
+        await catalog.versions()
+
+        mock_elgato(responses, second, catalog=NEXT_CATALOG, url=NEXT_ARCHIVE_URL)
+        refresh: asyncio.Task[Any] | None = None
+
+        original_read = catalog._read
+
+        async def read_and_meddle(start: int, length: int) -> bytes:
+            """Let Elgato publish a new release mid download, once."""
+            nonlocal refresh
+            if refresh is None:
+                refresh = asyncio.create_task(catalog.versions(refresh=True))
+                await asyncio.sleep(0)
+            return await original_read(start, length)
+
+        with patch.object(catalog, "_read", read_and_meddle):
+            image = await catalog.download(53)
+
+        assert refresh is not None
+        await refresh
+
+        assert image.data == firmware
+        assert served
+
+
+async def test_download_for_a_board_elgato_skips(
+    responses: aioresponses,
+    archive: bytes,
+) -> None:
+    """Test asking for an image Elgato does not publish."""
+    mock_elgato(responses, archive)
+
+    async with FirmwareCatalog() as catalog:
+        with pytest.raises(ElgatoFirmwareError, match="board type 70"):
+            await catalog.download(70)


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`FirmwareCatalog.download()` reads an image in pieces, at offsets that only mean anything in the archive they came from. Nothing stopped `versions(refresh=True)` landing between two of those reads, and a refresh that finds a new Control Center replaces `_archive_url`, `_archive_size` and `_members`. The rest of the download then comes out of a different file, at the old file's offsets.

Not theoretical. The test for it fails on `main` with:

```
elgato.exceptions.ElgatoFirmwareError: Firmware has bad magic 0x6E6E, expected 0x00CE
```

`0x6E6E` is `nn`, padding text from the second archive, read where the firmware header should have been.

The window is small, but it became reachable when Home Assistant started sharing one catalog across every device: a scheduled refresh, or someone pressing "check for updates", can now land during an install on another light.

Both operations go through a lock. Reading the index moved into a private helper so `download()` can take the lock once rather than reaching through `latest()`.

Checked against the live CDN too: a download and a refresh fired together complete in 0.43s and the image still verifies.

Spotted in review on home-assistant/core#180786.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
